### PR TITLE
fix missing extension in url

### DIFF
--- a/gradio_server.py
+++ b/gradio_server.py
@@ -186,7 +186,7 @@ quantizeTransformer = args.quantize_transformer
 
 transformer_choices_t2v=["ckpts/wan2.1_text2video_1.3B_bf16.safetensors", "ckpts/wan2.1_text2video_14B_bf16.safetensors", "ckpts/wan2.1_text2video_14B_quanto_int8.safetensors"]   
 transformer_choices_i2v=["ckpts/wan2.1_image2video_480p_14B_bf16.safetensors", "ckpts/wan2.1_image2video_480p_14B_quanto_int8.safetensors", "ckpts/wan2.1_image2video_720p_14B_bf16.safetensors", "ckpts/wan2.1_image2video_720p_14B_quanto_int8.safetensors"]
-text_encoder_choices = ["ckpts/models_t5_umt5-xxl-enc-bf16", "ckpts/models_t5_umt5-xxl-enc-quanto_int8.safetensors"]
+text_encoder_choices = ["ckpts/models_t5_umt5-xxl-enc-bf16.safetensors", "ckpts/models_t5_umt5-xxl-enc-quanto_int8.safetensors"]
 
 server_config_filename = "gradio_config.json"
 


### PR DESCRIPTION
Missing `.safetensors` extension in url results in 404 when downloading t5 bf16 model

![image](https://github.com/user-attachments/assets/48eecad0-01ab-43d5-9ab4-21369f74f5fe)
