### PR TITLE
Fix a bug with deleting variable in `wan/modules/sage2_core.py` before referencing it.

### DIFF
--- a/wan/modules/sage2_core.py
+++ b/wan/modules/sage2_core.py
@@ -1076,12 +1076,13 @@ def sageattn_qk_int8_pv_fp8_cuda_sm90(
 
     q_size = q.size()
     q_device = q.device
-    del q,k
-
+    del q
 
     # pad v to multiple of 128
     # TODO: modify per_channel_fp8 kernel to handle this
     kv_len = k.size(seq_dim)
+    del k
+
     v_pad_len = 128 - (kv_len % 128) if kv_len % 128 != 0 else 0
     if v_pad_len > 0:
         if tensor_layout == "HND":


### PR DESCRIPTION
I might have found a bug in `wan/modules/sage2_core.py` in line `1079` which occurs only if you use **Sage Attention v2**. Here's a small code reference:

```python
1077    q_size = q.size()
1078    q_device = q.device
1079    del q,k
1080
1081
1082    # pad v to multiple of 128
1083    # TODO: modify per_channel_fp8 kernel to handle this
1084    kv_len = k.size(seq_dim)
```

First we delete `k` in line `1079` and then we reference it in line `1084`. We need to calculate `kv_len` prior to deleting `k`.
