### PR TITLE
Fixed invalid use of any() in wgp.py

### DIFF
--- a/wgp.py
+++ b/wgp.py
@@ -1746,7 +1746,8 @@ def get_model_filename(model_type, quantization ="int8", dtype_policy = ""):
         else:
             raw_filename = choices[0]
 
-    if dtype == torch.float16 and not any("fp16","FP16") in raw_filename and model_family == "wan" and finetune_def == None :
+    if (dtype == torch.float16 and not any(s in raw_filename for s in ("fp16", "FP16")) and model_family == "wan"
+            and finetune_def is None):
         if "quanto_int8" in raw_filename:
             raw_filename = raw_filename.replace("quanto_int8", "quanto_fp16_int8")
         elif "quanto_bf16_int8" in raw_filename:

--- a/wgp.py
+++ b/wgp.py
@@ -1746,7 +1746,7 @@ def get_model_filename(model_type, quantization ="int8", dtype_policy = ""):
         else:
             raw_filename = choices[0]
 
-    if dtype == torch.float16 and "fp16" not in raw_filename.lower() and model_family == "wan" and finetune_def is None:
+    if dtype == torch.float16 and "fp16" not in str(raw_filename).lower() and model_family == "wan" and finetune_def is None:
         if "quanto_int8" in raw_filename:
             raw_filename = raw_filename.replace("quanto_int8", "quanto_fp16_int8")
         elif "quanto_bf16_int8" in raw_filename:

--- a/wgp.py
+++ b/wgp.py
@@ -1746,8 +1746,7 @@ def get_model_filename(model_type, quantization ="int8", dtype_policy = ""):
         else:
             raw_filename = choices[0]
 
-    if (dtype == torch.float16 and not any(s in raw_filename for s in ("fp16", "FP16")) and model_family == "wan"
-            and finetune_def is None):
+    if dtype == torch.float16 and "fp16" not in raw_filename.lower() and model_family == "wan" and finetune_def is None:
         if "quanto_int8" in raw_filename:
             raw_filename = raw_filename.replace("quanto_int8", "quanto_fp16_int8")
         elif "quanto_bf16_int8" in raw_filename:


### PR DESCRIPTION
This was never going to work:

    if dtype == torch.float16 and not any("fp16","FP16") in raw_filename and model_family == "wan" and finetune_def == None :

Replaced with:

    if (dtype == torch.float16 and not any(s in raw_filename for s in ("fp16", "FP16")) and model_family == "wan"
            and finetune_def is None):

Which looked very much like what an AI would write (because an AI did write it), so I stopped being lazy and just wrote:

    if dtype == torch.float16 and "fp16" not in raw_filename.lower() and model_family == "wan" and finetune_def is None:
    
Upon reflection, I'm not sure why you're checking for FP16 since the rest of your checks are only in lowercase.  