### PR TITLE
Better solution for checking fp16 model names

### DIFF
--- a/wgp.py
+++ b/wgp.py
@@ -1746,7 +1746,11 @@ def get_model_filename(model_type, quantization ="int8", dtype_policy = ""):
         else:
             raw_filename = choices[0]
 
-    if dtype == torch.float16 and not any(x in raw_filename for x in ["fp16", "FP16"]) and model_family == "wan" and finetune_def == None:
+    if (isinstance(raw_filename, str)
+            and dtype == torch.float16
+            and "fp16" not in raw_filename.lower()
+            and model_family == "wan"
+            and finetune_def is None):
         if "quanto_int8" in raw_filename:
             raw_filename = raw_filename.replace("quanto_int8", "quanto_fp16_int8")
         elif "quanto_bf16_int8" in raw_filename:


### PR DESCRIPTION
You are right, this is a better solution.

```
    if (isinstance(raw_filename, str)
            and dtype == torch.float16
            and "fp16" not in raw_filename.lower()
            and model_family == "wan"
            and finetune_def is None):
```