### PR TITLE
Fix for AMD error when not using tiled VAE decoding

### DIFF
--- a/wan/modules/vae.py
+++ b/wan/modules/vae.py
@@ -35,30 +35,25 @@ class CausalConv3d(nn.Conv3d):
         x = F.pad(x, padding)
         try:
             out = super().forward(x)
-            print("(ran fine)")
             return out
         except RuntimeError as e:
             if "miopenStatus" in str(e):
-                print("⚠️ MIOpen fallback: running Conv3d on CPU")
-
+                print("⚠️ MIOpen fallback: AMD gets upset when trying to work with large areas, and so CPU will be "
+                      "used for this decoding (which is very slow). Consider using tiled VAE Decoding.")
                 x_cpu = x.float().cpu()
                 weight_cpu = self.weight.float().cpu()
                 bias_cpu = self.bias.float().cpu() if self.bias is not None else None
-
                 print(f"[Fallback] x shape: {x_cpu.shape}, weight shape: {weight_cpu.shape}")
                 out = F.conv3d(x_cpu, weight_cpu, bias_cpu,
-                               self.stride, (0, 0, 0),  # <-- FIX: no padding here
+                               self.stride, (0, 0, 0),  # avoid double padding here
                                self.dilation, self.groups)
-
                 out = out.to(x.device)
                 if x.dtype in (torch.float16, torch.bfloat16):
                     out = out.half()
                 if x.dtype != out.dtype:
                     out = out.to(x.dtype)
-                print("... returned (from CPU fallback)")
                 return out
             raise
-
 
 
 class RMS_norm(nn.Module):


### PR DESCRIPTION
Your code run on AMD Radeon 7800 and 7900 series graphics cards, if the new pytorch-amd-windows wheels are used.  See https://github.com/sfinktah/amd-torch for more information.

I haven't yet had time to write proper instructions for Wan2GP, and there are still some issues I have to resolve with on-the-fly quantisation (I'll talk to you when I am sure).

This PR is because AMD does not like doing untiled VAE decodes, and emits a very unhelpful error message.  This will make it use CPU (slow slow slow), and emit a more helpful message (if the user is reading their console).

This PR is **not required** to make Wan2GP run on AMD, but it will avoid people asking about a strange error if they don't use tiled VAE decoding.