### PR TITLE
Fix broken help menu

### DIFF
--- a/wgp.py
+++ b/wgp.py
@@ -1462,7 +1462,7 @@ def _parse_args():
         "--perc-reserved-mem-max",
         type=float,
         default=0,
-        help="% of RAM allocated to Reserved RAM"
+        help="percent of RAM allocated to Reserved RAM"
     )
 
 


### PR DESCRIPTION
You cannot use the % symbol in your add_argument `help`

Fix #546