### PR TITLE
Fix: Prevent IndexError in get_loras_transformer

### DIFF
--- a/models/qwen/qwen_main.py
+++ b/models/qwen/qwen_main.py
@@ -214,9 +214,11 @@ class model_factory():
         if image is None: return None
         return image.transpose(0, 1)
 
-    def get_loras_transformer(self, get_model_recursive_prop, model_type, model_mode, **kwargs):
-        if model_mode == 0: return [], []
-        preloadURLs = get_model_recursive_prop(model_type,  "preload_URLs")
-        return [os.path.join("ckpts", os.path.basename(preloadURLs[0]))] , [1]
+	def get_loras_transformer(self, get_model_recursive_prop, model_type, model_mode, **kwargs):
+		if model_mode == 0: return [], []
+		preloadURLs = get_model_recursive_prop(model_type,  "preload_URLs")
+		if not preloadURLs:
+		return [], []
+		return [os.path.join("ckpts", os.path.basename(preloadURLs[0]))] , [1]
 
 


### PR DESCRIPTION
This commit addresses an `IndexError` that occurs in the `get_loras_transformer` function within
     `app/models/qwen/qwen_main.py`.

The error happens when the `get_model_recursive_prop` function returns an empty list for `preloadURLs`, causing a crash when the code attempts to access `preloadURLs[0]`.

The fix introduces a check to ensure that the `preloadURLs` list is not empty before attempting to access its elements. If the list is empty, the function now returns two empty lists, mirroring the behavior of when `model_mode` is 0. This prevents the crash and allows the application to continue running smoothly.