### PR TITLE
Fix crash when missing files encountered during gallery refresh (resolved conflicts)

### DIFF
--- a/wgp.py
+++ b/wgp.py
@@ -3186,17 +3186,52 @@ def abort_generation(state):
         return gr.Button(interactive=  True)
 
 
+def cleanup_missing_files(gen):
+    file_list = gen.get("file_list", [])
+    file_settings_list = gen.get("file_settings_list", [])
+
+    if not file_list:
+        return 0
+
+    original_count = len(file_list)
+
+    valid_items = [
+        (file_path, file_settings_list[i] if i < len(file_settings_list) else None)
+        for i, file_path in enumerate(file_list)
+        if os.path.exists(file_path)
+    ]
+
+    removed_count = original_count - len(valid_items)
+
+    if removed_count > 0:
+        print(f"Gallery refresh: Removed {removed_count} missing file(s) from view.")
+        if valid_items:
+            gen["file_list"], gen["file_settings_list"] = zip(*valid_items)
+            gen["file_list"] = list(gen["file_list"])
+            gen["file_settings_list"] = list(gen["file_settings_list"])
+        else:
+            gen["file_list"] = []
+            gen["file_settings_list"] = []
+
+    return removed_count
+
 
 def refresh_gallery(state): #, msg
     gen = get_gen_info(state)
 
-    # gen["last_msg"] = msg
-    file_list = gen.get("file_list", None)      
-    choice = gen.get("selected",0)
+    # Clean up any missing files first
+    cleanup_missing_files(gen)
+
+    # Now get the cleaned file list
+    file_list = gen.get("file_list", [])
+    choice = gen.get("selected", 0)
     header_text = gen.get("header_text", "")
     in_progress = "in_progress" in gen
-    if gen.get("last_selected", True) and file_list is not None:
-        choice = max(len(file_list) - 1,0)  
+    if gen.get("last_selected", True) and file_list:
+        choice = max(len(file_list) - 1, 0)
+
+    # Ensure choice is valid after cleanup
+    choice = min(choice, len(file_list) - 1 if file_list else 0)
 
     queue = gen.get("queue", [])
     abort_interactive = not gen.get("abort", False)
@@ -3323,6 +3358,10 @@ def select_video(state, input_file_list, event_data: gr.EventData):
     if len(file_list) > 0:
         configs = file_settings_list[choice]
         file_name = file_list[choice]
+        if not os.path.exists(file_name):
+            gr.Warning(f"File not found: {os.path.basename(file_name)}. It may have been moved or deleted.")
+            visible = False
+            return choice, get_default_video_info(), gr.update(visible=visible), gr.update(visible=visible), gr.update(visible=visible) , gr.update(visible=visible)
         values = [  os.path.basename(file_name)]
         labels = [ "File Name"]
         misc_values= []


### PR DESCRIPTION
All code was generated with AI.

## 🐛 Bug Fix

This PR resolves the gallery refresh crash issue described in #577 by implementing proper file existence validation.

### 🔧 Changes Made
- **Added `cleanup_missing_files()` function**: Removes missing files from gallery lists before processing
- **Enhanced `refresh_gallery()`**: Calls cleanup before processing to prevent crashes
- **Improved validation**: Better bounds checking and file existence validation
- **Maintained data consistency**: Keeps `file_list` and `file_settings_list` synchronized

### 🎯 Problem Solved
Fixes server crashes that occur when:
- Video files are deleted externally before Gradio caches them
- Gallery refresh operations encounter missing files
- File list becomes out of sync with actual filesystem

### 🔗 Related
- Resolves #577
- Based on original work by @scm6079 in #670 (with resolved merge conflicts)

### 📝 Technical Details
The fix adds a cleanup step at the beginning of `refresh_gallery()` that:
1. Checks file existence for all items in `file_list`
2. Removes missing files and their corresponding settings
3. Updates both lists atomically to maintain consistency
4. Provides user feedback about removed files

This prevents downstream crashes while maintaining a clean user experience.