### PR TITLE
Add move to top/bottom functionality to queue management

### DIFF
--- a/wgp.py
+++ b/wgp.py
@@ -1375,8 +1375,8 @@ def get_queue_table(queue):
                     end_img_md,
                     "↑",
                     "↓",
-                    "⭱",
-                    "⭳",
+                    "⤊",
+                    "⤋",
                     "✖"
                     ])    
     return data
@@ -6837,8 +6837,8 @@ def handle_celll_selection(state, evt: gr.SelectData):
     if col_index in [6, 7, 8, 9, 10]:
         if col_index == 6: cell_value = "↑"
         elif col_index == 7: cell_value = "↓"
-        elif col_index == 8: cell_value = "⭱"
-        elif col_index == 9: cell_value = "⭳"
+        elif col_index == 8: cell_value = "⤊"
+        elif col_index == 9: cell_value = "⤋"
         elif col_index == 10: cell_value = "✖"
     if col_index == 6:
         new_df_data = move_up(queue, [row_index])
@@ -8386,7 +8386,7 @@ def generate_video_tab(update_form = False, state_dict = None, ui_defaults = Non
                         queue_df = gr.DataFrame(
                             headers=["Qty","Prompt", "Length","Steps","", "", "", "", "", "", ""],
                             datatype=[ "str","markdown","str", "markdown", "markdown", "markdown", "str", "str", "str", "str", "str"],
-                            column_widths= ["5%", None, "7%", "7%", "10%", "10%", "3%", "3%", "3%", "3%", "3%"],
+                            column_widths= ["5%", None, "7%", "7%", "10%", "10%", "3%", "3%", "30", "30", "30"],
                             interactive=False,
                             col_count=(11, "fixed"),
                             wrap=True,

--- a/wgp.py
+++ b/wgp.py
@@ -1373,9 +1373,9 @@ def get_queue_table(queue):
                     num_steps,
                     start_img_md,
                     end_img_md,
-                    "⭱",
                     "↑",
                     "↓",
+                    "⭱",
                     "⭳",
                     "✖"
                     ])    
@@ -6835,19 +6835,19 @@ def handle_celll_selection(state, evt: gr.SelectData):
     row_index, col_index = evt.index
     cell_value = None
     if col_index in [6, 7, 8, 9, 10]:
-        if col_index == 6: cell_value = "⭱"
-        elif col_index == 7: cell_value = "↑"
-        elif col_index == 8: cell_value = "↓"
+        if col_index == 6: cell_value = "↑"
+        elif col_index == 7: cell_value = "↓"
+        elif col_index == 8: cell_value = "⭱"
         elif col_index == 9: cell_value = "⭳"
         elif col_index == 10: cell_value = "✖"
     if col_index == 6:
-        new_df_data = move_to_top(queue, [row_index])
-        return new_df_data, gr.update(), gr.update(visible=False)
-    elif col_index == 7:
         new_df_data = move_up(queue, [row_index])
         return new_df_data, gr.update(), gr.update(visible=False)
-    elif col_index == 8:
+    elif col_index == 7:
         new_df_data = move_down(queue, [row_index])
+        return new_df_data, gr.update(), gr.update(visible=False)
+    elif col_index == 8:
+        new_df_data = move_to_top(queue, [row_index])
         return new_df_data, gr.update(), gr.update(visible=False)
     elif col_index == 9:
         new_df_data = move_to_bottom(queue, [row_index])

--- a/wgp.py
+++ b/wgp.py
@@ -1375,8 +1375,8 @@ def get_queue_table(queue):
                     end_img_md,
                     "↑",
                     "↓",
-                    "⤊",
-                    "⤋",
+                    "⭱",
+                    "⭳",
                     "✖"
                     ])    
     return data
@@ -6837,8 +6837,8 @@ def handle_celll_selection(state, evt: gr.SelectData):
     if col_index in [6, 7, 8, 9, 10]:
         if col_index == 6: cell_value = "↑"
         elif col_index == 7: cell_value = "↓"
-        elif col_index == 8: cell_value = "⤊"
-        elif col_index == 9: cell_value = "⤋"
+        elif col_index == 8: cell_value = "⭱"
+        elif col_index == 9: cell_value = "⭳"
         elif col_index == 10: cell_value = "✖"
     if col_index == 6:
         new_df_data = move_up(queue, [row_index])
@@ -8386,7 +8386,7 @@ def generate_video_tab(update_form = False, state_dict = None, ui_defaults = Non
                         queue_df = gr.DataFrame(
                             headers=["Qty","Prompt", "Length","Steps","", "", "", "", "", "", ""],
                             datatype=[ "str","markdown","str", "markdown", "markdown", "markdown", "str", "str", "str", "str", "str"],
-                            column_widths= ["5%", None, "7%", "7%", "10%", "10%", "3%", "3%", "30", "30", "30"],
+                            column_widths= ["5%", None, "7%", "7%", "10%", "10%", "3%", "3%", "30", "30", "34"],
                             interactive=False,
                             col_count=(11, "fixed"),
                             wrap=True,


### PR DESCRIPTION
All code is AI generated.

## Changes
- Added **move to top** (⭱) and **move to bottom** (⭳) buttons to queue management
- New functions: `move_to_top()` and `move_to_bottom()`
- Extended queue DataFrame from 9 to 11 columns
- Table width remains constant (Prompt column is flexible and auto-adjusts)
- Updated click handler to support the new column indices
- Button order optimized for UX: single-step movements before jump-to-end movements

## UI Changes
The queue table now has these buttons in order:
- **↑** (width 3%) - Move item up one position
- **↓** (width 3%) - Move item down one position
- **⭱** (width 30px) - Move item to top of queue (position 1, after current generation)
- **⭳** (width 30px) - Move item to bottom of queue
- **✖** (width 34px) - Remove item

This makes it much easier to reorder queue items without multiple clicks, with an intuitive progression from small to large movements.