### PR TITLE
Make It Portable

### DIFF
--- a/wgp.py
+++ b/wgp.py
@@ -1,11 +1,11 @@
-import os
+import sys, os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '.')))
 os.environ["GRADIO_LANG"] = "en"
 # # os.environ.pop("TORCH_LOGS", None)  # make sure no env var is suppressing/overriding
 # os.environ["TORCH_LOGS"]= "recompiles"
 import torch._logging as tlog
 # tlog.set_logs(recompiles=True, guards=True, graph_breaks=True)    
 import time
-import sys
 import threading
 import argparse
 from mmgp import offload, safetensors2, profile_type 


### PR DESCRIPTION
This change ensures that WanGP can be run with an embedded Python distribution by allowing it to reliably find its local modules, making the app more portable.
For example, if you want to create a portable application, similar to ComfyUI, that can be launched from a batch file
<img width="824" height="406" alt="Screenshot 2025-10-12 085307" src="https://github.com/user-attachments/assets/9d603195-2b4a-4c4e-9a38-4a061ad8282f" />
