### PR TITLE
Corrected background colors in audio gallery styles from white that could not be read in dark mode to a darker theme.

### DIFF
--- a/shared/gradio/audio_gallery.py
+++ b/shared/gradio/audio_gallery.py
@@ -472,7 +472,7 @@ AG.tryInstall();
 
             .selected-filename {{
                 padding: 4px 12px;
-                background: #f0f0f0;
+                background: #27272a;
                 border-radius: 4px;
                 font-size: 14px;
                 font-weight: 500;
@@ -493,7 +493,7 @@ AG.tryInstall();
                 flex-direction: row;
                 border: 1px solid #e0e0e0;
                 border-radius: 8px;
-                background: #fafafa;
+                background: #27272a;
                 min-height: 120px;
             }}
 
@@ -506,7 +506,7 @@ AG.tryInstall();
                 border: 2px solid #d0d0d0;
                 border-radius: 8px;
                 cursor: pointer;
-                background: white;
+                background: #27272a;
                 transition: all 0.2s ease;
                 display: flex;
                 flex-direction: column;
@@ -542,7 +542,7 @@ AG.tryInstall();
 
             .audio-thumbnail.selected {{
                 border-color: #2196F3;
-                background: #E3F2FD;
+                background: #27272a;
                 box-shadow: 0 2px 12px rgba(33, 150, 243, 0.4);
             }}
 


### PR DESCRIPTION
Chatterbox gradio (Dark Mode) the "selected file name", "audio gallery" & "Thumbnails" are all completely White and you can't read the text. I made a change in "audio.gallery.py" file to fix them. I also looked at the "audio gallery" tab on other models and they were also white in (dark mode) not sure about "light mode" as I only use "dark mode". Hope this helps. Thank you.

Line 475  background: #27272a;

Line 496  background: #27272a;

Line 509  background: #27272a;

Line 545  background: #27272a;

<img width="1916" height="931" alt="Screenshot 2025-10-21 191432" src="https://github.com/user-attachments/assets/fa8e5aeb-7f9b-4fbd-b7cd-33a1bcca6b9c" />

<img width="1914" height="929" alt="Screenshot 2025-10-21 191055" src="https://github.com/user-attachments/assets/ec70f38a-4426-474d-a355-e193b3d51aae" />
