### PR TITLE
Fix I2V architecture T2V mode: pad latents to 36 channels for patch_e…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ loras_i2v/
 settings/
 
 wgp_config.json
+
+ffmpeg_bins/
+
+finetunes/*.json


### PR DESCRIPTION
# Fix I2V Architecture T2V Mode: Pad Latents to 36 Channels for Patch Embedding Compatibility

## Problem
When using I2V architecture models (like `i2v_2_2`) in T2V mode, the model expects 36-channel input latents (via `patch_embedding`'s `in_dim=36`), but the code was creating 16-channel latents (VAE's `z_dim=16`). This caused a `RuntimeError: expected input to have 36 channels but got 16/32 channels`.

This issue was encountered when using the [Omega Uncensored V6 - Libidinous Infernalis V2](https://civitai.com/models/2100349/omega-uncensored-v6) model, which is trained on I2V architecture but supports both I2V and T2V modes.

## Solution
- Changed `target_shape` to always use VAE's `z_dim` (16 channels) for creating latents
- Added padding logic to expand 16-channel latents to 36 channels before passing to the model
- Padding is applied after all concatenations to ensure correct channel count
- The model's `out_dim=16` ensures latents are updated correctly in the scheduler

## Changes
- `models/wan/any2video.py`: Added padding logic to pad latents from 16 to 36 channels when model's `in_dim=36`
- `.gitignore`: Added `finetunes/*.json` to ignore finetune configuration files

## Testing
Tested with:
- Model: [Omega Uncensored V6 - Libidinous Infernalis V2](https://civitai.com/models/2100349/omega-uncensored-v6)
- Architecture: `i2v_2_2` 
- Mode: T2V (Text-to-Video)
- Result: Successfully generates videos without channel mismatch errors

## Technical Details
For I2V architecture models:
- `in_dim=36`: patch_embedding expects 36 channels (16 VAE channels + 20 CLIP vision channels)
- `out_dim=16`: model outputs 16 channels
- In T2V mode, CLIP vision features (`y`) are `None`, so we pad the 16-channel latents with zeros to reach 36 channels before the patch_embedding layer

