### PR TITLE
Add Prompt Library plugin for Wan2GP

### DIFF
--- a/plugins/wan2gp-prompt-library/README.md
+++ b/plugins/wan2gp-prompt-library/README.md
@@ -1,0 +1,185 @@
+# Wan2GP Prompt Library Plugin
+
+A comprehensive prompt management system that lets you save, organize, and reuse prompts with their associated generation settings.
+
+## Features
+
+- 📚 **Organize prompts** in collections (Favorites, Cinematic, Anime, Realistic, Character)
+- 🔍 **Search and filter** prompts by name, text, or tags
+- 📝 **Variable substitution** - use placeholders like `{location}` in prompts
+- ⚙️ **Save generation settings** - capture model, resolution, LoRAs, and other parameters
+- ⭐ **Favorites system** - mark your best prompts for quick access
+- 📊 **Usage tracking** - see which prompts you use most
+- 📤 **Import/Export** - share collections with the community
+- 🎨 **Starter templates** - pre-loaded examples to get you started
+
+## Installation
+
+### Enable the Plugin
+
+1. **Using Plugin Manager (Recommended)**:
+   - Open Wan2GP and go to the "Plugin Manager" tab
+   - Find "wan2gp-prompt-library" in the list
+   - Check the box to enable it
+   - Click "Save & Restart"
+
+2. **Manual Configuration**:
+   - Find your server config file (usually in the Wan2GP directory)
+   - Add `"wan2gp-prompt-library"` to the `enabled_plugins` array:
+   ```json
+   {
+     "enabled_plugins": [
+       "wan2gp-prompt-library"
+     ]
+   }
+   ```
+   - Restart Wan2GP
+
+## Usage
+
+### Browsing Prompts
+
+1. Click the "📚 Prompt Library" tab
+2. Select a collection from the left panel
+3. Use the search box or tag filters to find prompts
+4. Click on a prompt card to select it
+
+### Using a Prompt
+
+When you click a prompt card, you have two options:
+
+- **📝 Use Prompt Only**: Copies just the prompt text to the main generator
+- **⚙️ Use with Settings**: Copies the prompt AND applies all saved settings (model, resolution, LoRAs, etc.)
+
+If the prompt contains variables like `{location}`, you'll see a field to fill them in before use.
+
+### Saving a Prompt
+
+1. Generate a video with the settings you want
+2. In the Prompt Library tab, expand "💾 Save Current Prompt to Library"
+3. Enter a name and select a collection
+4. Add tags (comma-separated) for easier searching
+5. Check "Save current generation settings" if you want to capture model/resolution/LoRAs
+6. Click "💾 Save to Library"
+
+### Variable Substitution
+
+Create reusable prompt templates with variables:
+
+```
+Cinematic drone shot of {location}, {time_of_day} lighting, 4K quality
+```
+
+When you use this prompt, you'll be asked to fill in values:
+```
+location=mountains, time_of_day=golden hour
+```
+
+### Managing Collections
+
+- **Create**: Click "➕ New" in the Collections panel (requires manual JSON editing currently)
+- **Delete**: Select a collection and click "🗑️ Delete"
+- **Export**: Use the Import/Export section to save a collection as JSON
+- **Import**: Upload a JSON file to add prompts from another collection
+
+### Favorites
+
+Click the ⭐ button to add/remove a prompt from your Favorites collection for quick access.
+
+## File Storage
+
+Prompts are stored in: `~/.wan2gp/prompt_library.json`
+
+You can manually edit this file to:
+- Create new collections
+- Bulk edit prompts
+- Backup your library
+
+## Data Structure
+
+```json
+{
+  "version": "1.0.0",
+  "collections": {
+    "favorites": {
+      "name": "Favorites",
+      "icon": "⭐",
+      "prompts": [
+        {
+          "id": "uuid-here",
+          "name": "Epic Drone Shot",
+          "prompt": "Cinematic drone shot flying over {location}...",
+          "negative_prompt": "blurry, distorted",
+          "tags": ["aerial", "landscape", "cinematic"],
+          "variables": ["location"],
+          "settings": {
+            "model_type": "wan2.1-t2v-14B",
+            "resolution": "1280x720",
+            "steps": 30,
+            "guidance_scale": 7.5
+          },
+          "created": "2025-01-15T10:30:00Z",
+          "last_used": "2025-01-20T14:00:00Z",
+          "use_count": 12
+        }
+      ]
+    }
+  }
+}
+```
+
+## Starter Templates
+
+The plugin comes with pre-loaded templates in these collections:
+
+- **🎬 Cinematic**: Epic drone shots, slow motion, establishing shots, close-up portraits
+- **🎨 Anime**: Character actions, background scenes, magical girl transformations
+- **📷 Realistic**: Nature documentary, urban street scenes, product showcases, time lapses
+- **🎭 Character**: Walk cycles, talking animations, emotions, action sequences
+
+Feel free to modify or delete these templates as needed!
+
+## Sharing Collections
+
+To share your prompt collection with others:
+
+1. Go to the Import/Export section
+2. Select the collection to export
+3. Click "📤 Export Collection"
+4. Find the exported JSON in `~/.wan2gp/exports/`
+5. Share the JSON file
+
+To import someone else's collection:
+
+1. Download their JSON file
+2. Go to Import/Export section
+3. Upload the file
+4. Choose whether to merge or replace
+5. Click "📥 Import"
+
+## Tips
+
+- Use descriptive names for your prompts
+- Add multiple tags to make prompts easier to find
+- Save settings with prompts you've refined to perfection
+- Use variables for prompts you use often with different subjects
+- Check usage stats to see which prompts work best
+- Export your favorites regularly as backup
+
+## Troubleshooting
+
+**Plugin doesn't appear**: Make sure it's enabled in the server config or Plugin Manager
+
+**Prompts not saving**: Check that `~/.wan2gp/` directory exists and is writable
+
+**Variables not substituting**: Make sure you use the format `key=value, key2=value2` with commas between pairs
+
+**Settings not applying**: Try "Use with Settings" instead of "Use Prompt Only"
+
+## Version
+
+Current version: 1.0.0
+
+## License
+
+Same license as Wan2GP project.

--- a/plugins/wan2gp-prompt-library/__init__.py
+++ b/plugins/wan2gp-prompt-library/__init__.py
@@ -1,0 +1,11 @@
+"""
+Wan2GP Prompt Library Plugin
+
+A prompt management system that lets users save, organize, and reuse prompts
+with their associated generation settings.
+"""
+
+from .plugin import PromptLibraryPlugin
+
+__version__ = "1.0.0"
+__all__ = ["PromptLibraryPlugin"]

--- a/plugins/wan2gp-prompt-library/library.py
+++ b/plugins/wan2gp-prompt-library/library.py
@@ -1,0 +1,484 @@
+"""
+Prompt Library - Storage and retrieval logic for prompt templates
+"""
+
+import json
+import os
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Any
+
+
+class PromptLibrary:
+    """Manages prompt storage, retrieval, and organization"""
+
+    def __init__(self, library_path: Optional[str] = None):
+        """Initialize the prompt library
+
+        Args:
+            library_path: Custom path for library file. If None, uses ~/.wan2gp/prompt_library.json
+        """
+        if library_path is None:
+            home = Path.home()
+            wan2gp_dir = home / ".wan2gp"
+            wan2gp_dir.mkdir(exist_ok=True)
+            self.library_path = wan2gp_dir / "prompt_library.json"
+        else:
+            self.library_path = Path(library_path)
+
+        self.data = self._load_library()
+
+    def _load_library(self) -> Dict[str, Any]:
+        """Load library from disk or create default structure"""
+        if self.library_path.exists():
+            try:
+                with open(self.library_path, 'r', encoding='utf-8') as f:
+                    return json.load(f)
+            except Exception as e:
+                print(f"Error loading prompt library: {e}")
+                return self._create_default_library()
+        else:
+            return self._create_default_library()
+
+    def _create_default_library(self) -> Dict[str, Any]:
+        """Create default library structure with built-in collections"""
+        return {
+            "version": "1.0.0",
+            "collections": {
+                "favorites": {
+                    "name": "Favorites",
+                    "icon": "⭐",
+                    "prompts": []
+                },
+                "cinematic": {
+                    "name": "Cinematic",
+                    "icon": "🎬",
+                    "prompts": []
+                },
+                "anime": {
+                    "name": "Anime",
+                    "icon": "🎨",
+                    "prompts": []
+                },
+                "realistic": {
+                    "name": "Realistic",
+                    "icon": "📷",
+                    "prompts": []
+                },
+                "character": {
+                    "name": "Character",
+                    "icon": "🎭",
+                    "prompts": []
+                }
+            }
+        }
+
+    def save_library(self) -> bool:
+        """Save library to disk"""
+        try:
+            with open(self.library_path, 'w', encoding='utf-8') as f:
+                json.dump(self.data, f, indent=2, ensure_ascii=False)
+            return True
+        except Exception as e:
+            print(f"Error saving prompt library: {e}")
+            return False
+
+    def get_collection_names(self) -> List[tuple]:
+        """Get list of collection names with icons for display
+
+        Returns:
+            List of (display_name, collection_id) tuples
+        """
+        collections = []
+        for coll_id, coll_data in self.data["collections"].items():
+            icon = coll_data.get("icon", "📁")
+            name = coll_data.get("name", coll_id)
+            display = f"{icon} {name}"
+            collections.append((display, coll_id))
+        return collections
+
+    def get_collection(self, collection_id: str) -> Optional[Dict[str, Any]]:
+        """Get a collection by ID"""
+        return self.data["collections"].get(collection_id)
+
+    def create_collection(self, collection_id: str, name: str, icon: str = "📁") -> bool:
+        """Create a new collection
+
+        Args:
+            collection_id: Unique identifier for the collection
+            name: Display name
+            icon: Emoji icon
+
+        Returns:
+            True if created successfully
+        """
+        if collection_id in self.data["collections"]:
+            return False
+
+        self.data["collections"][collection_id] = {
+            "name": name,
+            "icon": icon,
+            "prompts": []
+        }
+        return self.save_library()
+
+    def delete_collection(self, collection_id: str) -> bool:
+        """Delete a collection
+
+        Args:
+            collection_id: Collection to delete
+
+        Returns:
+            True if deleted successfully
+        """
+        # Don't allow deletion of favorites
+        if collection_id == "favorites":
+            return False
+
+        if collection_id in self.data["collections"]:
+            del self.data["collections"][collection_id]
+            return self.save_library()
+        return False
+
+    def add_prompt(
+        self,
+        collection_id: str,
+        name: str,
+        prompt: str,
+        negative_prompt: str = "",
+        tags: Optional[List[str]] = None,
+        settings: Optional[Dict[str, Any]] = None
+    ) -> Optional[str]:
+        """Add a new prompt to a collection
+
+        Args:
+            collection_id: Collection to add to
+            name: Prompt name/title
+            prompt: The prompt text
+            negative_prompt: Negative prompt text
+            tags: List of tags
+            settings: Generation settings (model, resolution, etc.)
+
+        Returns:
+            Prompt ID if successful, None otherwise
+        """
+        collection = self.get_collection(collection_id)
+        if not collection:
+            return None
+
+        # Generate unique ID
+        prompt_id = str(uuid.uuid4())
+
+        # Extract variables from prompt (words in {curly braces})
+        import re
+        variables = re.findall(r'\{(\w+)\}', prompt)
+
+        prompt_data = {
+            "id": prompt_id,
+            "name": name,
+            "prompt": prompt,
+            "negative_prompt": negative_prompt,
+            "tags": tags or [],
+            "variables": list(set(variables)),  # Unique variables
+            "settings": settings or {},
+            "created": datetime.utcnow().isoformat() + "Z",
+            "last_used": None,
+            "use_count": 0
+        }
+
+        collection["prompts"].append(prompt_data)
+
+        if self.save_library():
+            return prompt_id
+        return None
+
+    def update_prompt(
+        self,
+        prompt_id: str,
+        name: Optional[str] = None,
+        prompt: Optional[str] = None,
+        negative_prompt: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        settings: Optional[Dict[str, Any]] = None
+    ) -> bool:
+        """Update an existing prompt
+
+        Args:
+            prompt_id: Prompt to update
+            name: New name (if provided)
+            prompt: New prompt text (if provided)
+            negative_prompt: New negative prompt (if provided)
+            tags: New tags (if provided)
+            settings: New settings (if provided)
+
+        Returns:
+            True if updated successfully
+        """
+        prompt_data = self.get_prompt(prompt_id)
+        if not prompt_data:
+            return False
+
+        if name is not None:
+            prompt_data["name"] = name
+        if prompt is not None:
+            prompt_data["prompt"] = prompt
+            # Recalculate variables
+            import re
+            variables = re.findall(r'\{(\w+)\}', prompt)
+            prompt_data["variables"] = list(set(variables))
+        if negative_prompt is not None:
+            prompt_data["negative_prompt"] = negative_prompt
+        if tags is not None:
+            prompt_data["tags"] = tags
+        if settings is not None:
+            prompt_data["settings"] = settings
+
+        return self.save_library()
+
+    def delete_prompt(self, prompt_id: str) -> bool:
+        """Delete a prompt from all collections
+
+        Args:
+            prompt_id: Prompt to delete
+
+        Returns:
+            True if deleted successfully
+        """
+        deleted = False
+        for collection in self.data["collections"].values():
+            prompts = collection["prompts"]
+            original_length = len(prompts)
+            collection["prompts"] = [p for p in prompts if p["id"] != prompt_id]
+            if len(collection["prompts"]) < original_length:
+                deleted = True
+
+        if deleted:
+            return self.save_library()
+        return False
+
+    def get_prompt(self, prompt_id: str) -> Optional[Dict[str, Any]]:
+        """Get a prompt by ID from any collection
+
+        Args:
+            prompt_id: Prompt ID to find
+
+        Returns:
+            Prompt data dict or None
+        """
+        for collection in self.data["collections"].values():
+            for prompt in collection["prompts"]:
+                if prompt["id"] == prompt_id:
+                    return prompt
+        return None
+
+    def get_prompts_in_collection(
+        self,
+        collection_id: str,
+        search: Optional[str] = None,
+        tags: Optional[List[str]] = None
+    ) -> List[Dict[str, Any]]:
+        """Get prompts from a collection with optional filtering
+
+        Args:
+            collection_id: Collection to search
+            search: Search string (matches name and prompt text)
+            tags: Filter by tags (must have at least one matching tag)
+
+        Returns:
+            List of matching prompts
+        """
+        collection = self.get_collection(collection_id)
+        if not collection:
+            return []
+
+        prompts = collection["prompts"]
+
+        # Apply search filter
+        if search and search.strip():
+            search_lower = search.lower()
+            prompts = [
+                p for p in prompts
+                if search_lower in p["name"].lower() or
+                   search_lower in p["prompt"].lower()
+            ]
+
+        # Apply tag filter
+        if tags:
+            prompts = [
+                p for p in prompts
+                if any(tag in p.get("tags", []) for tag in tags)
+            ]
+
+        # Sort by usage (most used first), then by last used
+        prompts = sorted(
+            prompts,
+            key=lambda p: (p.get("use_count", 0), p.get("last_used") or ""),
+            reverse=True
+        )
+
+        return prompts
+
+    def record_usage(self, prompt_id: str) -> bool:
+        """Record that a prompt was used
+
+        Args:
+            prompt_id: Prompt that was used
+
+        Returns:
+            True if recorded successfully
+        """
+        prompt = self.get_prompt(prompt_id)
+        if not prompt:
+            return False
+
+        prompt["use_count"] = prompt.get("use_count", 0) + 1
+        prompt["last_used"] = datetime.utcnow().isoformat() + "Z"
+
+        return self.save_library()
+
+    def find_by_prompt(self, prompt_text: str) -> Optional[Dict[str, Any]]:
+        """Find a prompt by exact prompt text match
+
+        Args:
+            prompt_text: Prompt text to search for
+
+        Returns:
+            First matching prompt or None
+        """
+        for collection in self.data["collections"].values():
+            for prompt in collection["prompts"]:
+                if prompt["prompt"] == prompt_text:
+                    return prompt
+        return None
+
+    def get_all_tags(self) -> List[str]:
+        """Get all unique tags across all prompts
+
+        Returns:
+            Sorted list of unique tags
+        """
+        tags = set()
+        for collection in self.data["collections"].values():
+            for prompt in collection["prompts"]:
+                tags.update(prompt.get("tags", []))
+        return sorted(tags)
+
+    def add_to_favorites(self, prompt_id: str) -> bool:
+        """Add a prompt to favorites collection
+
+        Args:
+            prompt_id: Prompt to add
+
+        Returns:
+            True if added successfully
+        """
+        prompt = self.get_prompt(prompt_id)
+        if not prompt:
+            return False
+
+        favorites = self.get_collection("favorites")
+        if not favorites:
+            return False
+
+        # Check if already in favorites
+        for fav_prompt in favorites["prompts"]:
+            if fav_prompt["id"] == prompt_id:
+                return True  # Already in favorites
+
+        # Add to favorites (by reference)
+        favorites["prompts"].append(prompt)
+        return self.save_library()
+
+    def remove_from_favorites(self, prompt_id: str) -> bool:
+        """Remove a prompt from favorites
+
+        Args:
+            prompt_id: Prompt to remove
+
+        Returns:
+            True if removed successfully
+        """
+        favorites = self.get_collection("favorites")
+        if not favorites:
+            return False
+
+        original_length = len(favorites["prompts"])
+        favorites["prompts"] = [
+            p for p in favorites["prompts"]
+            if p["id"] != prompt_id
+        ]
+
+        if len(favorites["prompts"]) < original_length:
+            return self.save_library()
+        return False
+
+    def is_in_favorites(self, prompt_id: str) -> bool:
+        """Check if a prompt is in favorites
+
+        Args:
+            prompt_id: Prompt to check
+
+        Returns:
+            True if in favorites
+        """
+        favorites = self.get_collection("favorites")
+        if not favorites:
+            return False
+
+        return any(p["id"] == prompt_id for p in favorites["prompts"])
+
+    def export_collection(self, collection_id: str) -> Optional[Dict[str, Any]]:
+        """Export a collection for sharing
+
+        Args:
+            collection_id: Collection to export
+
+        Returns:
+            Collection data dict or None
+        """
+        collection = self.get_collection(collection_id)
+        if not collection:
+            return None
+
+        return {
+            "version": self.data["version"],
+            "collection": {
+                collection_id: collection
+            }
+        }
+
+    def import_collection(self, collection_data: Dict[str, Any], merge: bool = False) -> bool:
+        """Import a collection from exported data
+
+        Args:
+            collection_data: Exported collection data
+            merge: If True, merge with existing. If False, replace.
+
+        Returns:
+            True if imported successfully
+        """
+        try:
+            if "collection" not in collection_data:
+                return False
+
+            for coll_id, coll_data in collection_data["collection"].items():
+                if coll_id in self.data["collections"] and not merge:
+                    # Replace existing
+                    self.data["collections"][coll_id] = coll_data
+                elif coll_id in self.data["collections"] and merge:
+                    # Merge prompts
+                    existing = self.data["collections"][coll_id]
+                    existing_ids = {p["id"] for p in existing["prompts"]}
+
+                    for prompt in coll_data["prompts"]:
+                        if prompt["id"] not in existing_ids:
+                            existing["prompts"].append(prompt)
+                else:
+                    # New collection
+                    self.data["collections"][coll_id] = coll_data
+
+            return self.save_library()
+        except Exception as e:
+            print(f"Error importing collection: {e}")
+            return False

--- a/plugins/wan2gp-prompt-library/plugin.py
+++ b/plugins/wan2gp-prompt-library/plugin.py
@@ -1,0 +1,841 @@
+"""
+Prompt Library Plugin for Wan2GP
+Save, organize, and reuse prompts with their generation settings
+"""
+
+import gradio as gr
+import json
+import time
+import re
+from pathlib import Path
+from typing import Dict, List, Any, Optional, Tuple
+
+from shared.utils.plugins import WAN2GPPlugin
+from .library import PromptLibrary
+from .templates import initialize_library_with_templates
+
+
+class PromptLibraryPlugin(WAN2GPPlugin):
+    """Plugin for managing and organizing prompt templates"""
+
+    def __init__(self):
+        super().__init__()
+        self.name = "Prompt Library"
+        self.version = "1.0.0"
+        self.description = "Save and organize prompt templates with settings"
+        self.library = PromptLibrary()
+
+        # Initialize with templates if library is empty
+        if self._is_library_empty():
+            initialize_library_with_templates(self.library)
+
+        # UI state
+        self.selected_prompt_id = None
+        self.selected_collection = "favorites"
+
+    def _is_library_empty(self) -> bool:
+        """Check if library has no prompts"""
+        for collection in self.library.data["collections"].values():
+            if collection["prompts"]:
+                return False
+        return True
+
+    def setup_ui(self):
+        """Setup plugin UI and request components"""
+        # Request access to main UI components
+        self.request_component("state")
+        self.request_component("main_tabs")
+        self.request_component("refresh_form_trigger")
+
+        # Request global functions
+        self.request_global("get_current_model_settings")
+        self.request_global("server_config")
+
+        # Register data hook to track prompt usage
+        self.register_data_hook('before_metadata_save', self.track_prompt_usage)
+
+        # Add the library tab
+        self.add_tab(
+            tab_id="prompt_library",
+            label="📚 Prompt Library",
+            component_constructor=self._build_ui,
+        )
+
+    def _build_ui(self):
+        """Build the main UI for the prompt library"""
+        with gr.Row():
+            # Left panel - Collections
+            with gr.Column(scale=1):
+                gr.Markdown("### Collections")
+                collection_choices = [name for name, _ in self.library.get_collection_names()]
+                self.collection_radio = gr.Radio(
+                    choices=collection_choices,
+                    value=collection_choices[0] if collection_choices else None,
+                    show_label=False,
+                    container=False
+                )
+
+                with gr.Row():
+                    self.new_collection_btn = gr.Button("➕ New", size="sm", scale=1)
+                    self.delete_collection_btn = gr.Button("🗑️ Delete", size="sm", scale=1, variant="stop")
+
+            # Right panel - Prompts
+            with gr.Column(scale=3):
+                # Search and filter bar
+                with gr.Row():
+                    self.search_box = gr.Textbox(
+                        placeholder="🔍 Search prompts...",
+                        show_label=False,
+                        scale=3
+                    )
+                    self.tag_filter = gr.Dropdown(
+                        choices=self.library.get_all_tags(),
+                        multiselect=True,
+                        label="Filter by tags",
+                        scale=2
+                    )
+
+                # Prompt gallery (HTML cards)
+                self.prompt_gallery = gr.HTML(
+                    value=self._render_prompt_gallery("favorites"),
+                    elem_id="prompt_library_gallery"
+                )
+
+                # Selected prompt details
+                with gr.Group(visible=False) as self.prompt_details_group:
+                    gr.Markdown("### Selected Prompt")
+
+                    with gr.Row():
+                        self.prompt_name_display = gr.Textbox(
+                            label="Name",
+                            interactive=False,
+                            scale=3
+                        )
+                        self.prompt_favorite_btn = gr.Button("⭐ Favorite", size="sm", scale=1)
+
+                    self.prompt_text_display = gr.Textbox(
+                        label="Prompt",
+                        lines=3,
+                        interactive=False
+                    )
+
+                    self.negative_prompt_display = gr.Textbox(
+                        label="Negative Prompt",
+                        lines=2,
+                        interactive=False
+                    )
+
+                    self.prompt_tags_display = gr.Textbox(
+                        label="Tags",
+                        interactive=False
+                    )
+
+                    # Variable substitution (shown only if prompt has variables)
+                    with gr.Row(visible=False) as self.variable_row:
+                        self.variable_inputs = gr.Textbox(
+                            label="Fill in variables (format: key=value, key2=value2)",
+                            placeholder="e.g., location=mountains, character=warrior",
+                            info="Replace {variables} in the prompt with your values"
+                        )
+
+                    # Action buttons
+                    with gr.Row():
+                        self.use_prompt_btn = gr.Button(
+                            "📝 Use Prompt Only",
+                            variant="secondary",
+                            scale=1
+                        )
+                        self.use_with_settings_btn = gr.Button(
+                            "⚙️ Use with Settings",
+                            variant="primary",
+                            scale=1
+                        )
+                        self.edit_prompt_btn = gr.Button("✏️ Edit", scale=1)
+                        self.delete_prompt_btn = gr.Button("🗑️ Delete", variant="stop", scale=1)
+
+        # Save current prompt section
+        with gr.Accordion("💾 Save Current Prompt to Library", open=False):
+            with gr.Row():
+                self.save_name = gr.Textbox(
+                    label="Prompt Name",
+                    placeholder="My awesome prompt",
+                    scale=2
+                )
+                self.save_collection = gr.Dropdown(
+                    choices=[coll_id for _, coll_id in self.library.get_collection_names()],
+                    label="Collection",
+                    value="favorites",
+                    scale=1
+                )
+
+            self.save_tags = gr.Textbox(
+                label="Tags (comma-separated)",
+                placeholder="cinematic, landscape, aerial"
+            )
+
+            self.save_include_settings = gr.Checkbox(
+                label="Save current generation settings (model, resolution, LoRAs, etc.)",
+                value=True
+            )
+
+            with gr.Row():
+                self.save_btn = gr.Button("💾 Save to Library", variant="primary")
+                self.save_status = gr.Markdown("")
+
+        # Import/Export section
+        with gr.Accordion("📤 Import/Export Collections", open=False):
+            with gr.Row():
+                self.import_file = gr.File(
+                    label="Import Collection JSON",
+                    file_types=[".json"]
+                )
+                self.import_merge_checkbox = gr.Checkbox(
+                    label="Merge with existing (instead of replace)",
+                    value=True
+                )
+                self.import_btn = gr.Button("📥 Import")
+
+            with gr.Row():
+                self.export_collection_choice = gr.Dropdown(
+                    choices=[coll_id for _, coll_id in self.library.get_collection_names()],
+                    label="Collection to Export",
+                    value="favorites"
+                )
+                self.export_btn = gr.Button("📤 Export Collection")
+
+            self.import_export_status = gr.Markdown("")
+
+        # Hidden state for selected prompt ID
+        self.selected_prompt_state = gr.State(value=None)
+
+        # Wire up events
+        self._setup_events()
+
+        # Add custom CSS for prompt cards
+        self._add_custom_css()
+
+    def _setup_events(self):
+        """Wire up all UI event handlers"""
+        # Collection selection
+        self.collection_radio.change(
+            fn=self._on_collection_change,
+            inputs=[self.collection_radio, self.search_box, self.tag_filter],
+            outputs=[self.prompt_gallery, self.prompt_details_group, self.selected_prompt_state]
+        )
+
+        # Search and filter
+        self.search_box.change(
+            fn=self._on_search_or_filter_change,
+            inputs=[self.collection_radio, self.search_box, self.tag_filter],
+            outputs=[self.prompt_gallery, self.prompt_details_group, self.selected_prompt_state]
+        )
+
+        self.tag_filter.change(
+            fn=self._on_search_or_filter_change,
+            inputs=[self.collection_radio, self.search_box, self.tag_filter],
+            outputs=[self.prompt_gallery, self.prompt_details_group, self.selected_prompt_state]
+        )
+
+        # Prompt card click (handled via JavaScript callback in HTML)
+        # The prompt ID is passed via the custom JS event
+
+        # Use prompt buttons
+        self.use_prompt_btn.click(
+            fn=self._use_prompt_only,
+            inputs=[self.state, self.selected_prompt_state, self.variable_inputs],
+            outputs=[self.main_tabs, self.save_status]
+        )
+
+        self.use_with_settings_btn.click(
+            fn=self._use_with_settings,
+            inputs=[self.state, self.selected_prompt_state, self.variable_inputs],
+            outputs=[self.refresh_form_trigger, self.main_tabs, self.save_status]
+        )
+
+        # Edit prompt
+        self.edit_prompt_btn.click(
+            fn=self._show_edit_dialog,
+            inputs=[self.selected_prompt_state],
+            outputs=[
+                self.prompt_name_display,
+                self.prompt_text_display,
+                self.negative_prompt_display,
+                self.prompt_tags_display
+            ]
+        )
+
+        # Delete prompt
+        self.delete_prompt_btn.click(
+            fn=self._delete_prompt,
+            inputs=[self.selected_prompt_state, self.collection_radio],
+            outputs=[self.prompt_gallery, self.prompt_details_group, self.save_status]
+        )
+
+        # Favorite button
+        self.prompt_favorite_btn.click(
+            fn=self._toggle_favorite,
+            inputs=[self.selected_prompt_state],
+            outputs=[self.save_status, self.prompt_favorite_btn]
+        )
+
+        # Save current prompt
+        self.save_btn.click(
+            fn=self._save_current_prompt,
+            inputs=[
+                self.state,
+                self.save_name,
+                self.save_collection,
+                self.save_tags,
+                self.save_include_settings
+            ],
+            outputs=[self.save_status, self.prompt_gallery, self.tag_filter]
+        )
+
+        # New collection
+        self.new_collection_btn.click(
+            fn=self._create_new_collection,
+            inputs=[],
+            outputs=[self.collection_radio, self.save_status]
+        )
+
+        # Delete collection
+        self.delete_collection_btn.click(
+            fn=self._delete_collection,
+            inputs=[self.collection_radio],
+            outputs=[self.collection_radio, self.prompt_gallery, self.save_status]
+        )
+
+        # Import/Export
+        self.import_btn.click(
+            fn=self._import_collection,
+            inputs=[self.import_file, self.import_merge_checkbox],
+            outputs=[self.import_export_status, self.collection_radio, self.prompt_gallery]
+        )
+
+        self.export_btn.click(
+            fn=self._export_collection,
+            inputs=[self.export_collection_choice],
+            outputs=[self.import_export_status]
+        )
+
+    def _render_prompt_gallery(self, collection_display_name: str, search: str = "", tags: List[str] = None) -> str:
+        """Render prompt cards as HTML
+
+        Args:
+            collection_display_name: Display name of collection (with icon)
+            search: Search filter
+            tags: Tag filters
+
+        Returns:
+            HTML string
+        """
+        # Extract collection ID from display name
+        collection_id = self._extract_collection_id(collection_display_name)
+        if not collection_id:
+            return "<p>Collection not found</p>"
+
+        prompts = self.library.get_prompts_in_collection(collection_id, search, tags)
+
+        if not prompts:
+            return "<div style='text-align: center; padding: 40px; color: #888;'>No prompts found. Add some prompts to get started!</div>"
+
+        html = "<div style='display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 16px;'>"
+
+        for prompt in prompts:
+            is_favorite = self.library.is_in_favorites(prompt["id"])
+            favorite_icon = "⭐" if is_favorite else "☆"
+
+            # Truncate prompt text for display
+            prompt_text = prompt["prompt"]
+            if len(prompt_text) > 100:
+                prompt_text = prompt_text[:100] + "..."
+
+            # Format tags
+            tag_html = ""
+            for tag in prompt.get("tags", [])[:3]:  # Show max 3 tags
+                tag_html += f'<span style="background: #e3f2fd; padding: 2px 8px; border-radius: 4px; font-size: 12px; margin-right: 4px;">{tag}</span>'
+
+            # Format usage stats
+            use_count = prompt.get("use_count", 0)
+            stats = f"Used {use_count}x"
+
+            # Variables indicator
+            variables_html = ""
+            if prompt.get("variables"):
+                var_count = len(prompt["variables"])
+                variables_html = f'<span style="color: #ff9800; font-size: 12px;">📝 {var_count} variable{"s" if var_count > 1 else ""}</span>'
+
+            html += f"""
+            <div onclick="selectPrompt('{prompt['id']}')"
+                 style="border: 1px solid #ddd; border-radius: 8px; padding: 16px; cursor: pointer;
+                        transition: all 0.2s; background: white;"
+                 onmouseover="this.style.boxShadow='0 4px 8px rgba(0,0,0,0.1)'; this.style.transform='translateY(-2px)'"
+                 onmouseout="this.style.boxShadow='none'; this.style.transform='translateY(0)'">
+                <div style="display: flex; justify-content: space-between; align-items: start; margin-bottom: 8px;">
+                    <strong style="font-size: 16px;">{prompt['name']}</strong>
+                    <span style="font-size: 20px;">{favorite_icon}</span>
+                </div>
+                <p style="color: #666; font-size: 14px; margin: 8px 0;">{prompt_text}</p>
+                <div style="margin: 8px 0;">{tag_html}</div>
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-top: 12px;">
+                    <span style="color: #888; font-size: 12px;">{stats}</span>
+                    {variables_html}
+                </div>
+            </div>
+            """
+
+        html += "</div>"
+
+        # Add JavaScript for card selection
+        html += """
+        <script>
+        function selectPrompt(promptId) {
+            // Store selected prompt ID
+            window.selectedPromptId = promptId;
+
+            // Trigger Gradio update
+            const event = new CustomEvent('promptSelected', { detail: { promptId: promptId } });
+            window.dispatchEvent(event);
+
+            console.log('Selected prompt:', promptId);
+        }
+        </script>
+        """
+
+        return html
+
+    def _extract_collection_id(self, display_name: str) -> Optional[str]:
+        """Extract collection ID from display name"""
+        for display, coll_id in self.library.get_collection_names():
+            if display == display_name:
+                return coll_id
+        return None
+
+    def _on_collection_change(self, collection_display: str, search: str, tags: List[str]) -> Tuple:
+        """Handle collection selection change"""
+        self.selected_collection = self._extract_collection_id(collection_display)
+        gallery_html = self._render_prompt_gallery(collection_display, search, tags)
+        return gallery_html, gr.update(visible=False), None
+
+    def _on_search_or_filter_change(self, collection_display: str, search: str, tags: List[str]) -> Tuple:
+        """Handle search or filter change"""
+        gallery_html = self._render_prompt_gallery(collection_display, search, tags)
+        return gallery_html, gr.update(visible=False), None
+
+    def _use_prompt_only(self, state: Dict, prompt_id: Optional[str], variables: str) -> Tuple:
+        """Copy just the prompt text to the main input
+
+        Args:
+            state: Application state
+            prompt_id: ID of prompt to use
+            variables: Variable substitutions
+
+        Returns:
+            Tuple of (tab_update, status_message)
+        """
+        if not prompt_id:
+            return gr.update(), "⚠️ Please select a prompt first"
+
+        prompt_data = self.library.get_prompt(prompt_id)
+        if not prompt_data:
+            return gr.update(), "❌ Prompt not found"
+
+        # Substitute variables
+        final_prompt = self._substitute_variables(prompt_data["prompt"], variables)
+
+        # Update state with new prompt
+        if self.get_current_model_settings:
+            settings = self.get_current_model_settings(state)
+            settings["prompt"] = final_prompt
+            if prompt_data.get("negative_prompt"):
+                settings["negative_prompt"] = prompt_data["negative_prompt"]
+
+        # Record usage
+        self.library.record_usage(prompt_id)
+
+        # Switch to video generation tab
+        return gr.Tabs(selected="video_gen"), f"✅ Loaded prompt: {prompt_data['name']}"
+
+    def _use_with_settings(self, state: Dict, prompt_id: Optional[str], variables: str) -> Tuple:
+        """Copy prompt AND apply all saved settings
+
+        Args:
+            state: Application state
+            prompt_id: ID of prompt to use
+            variables: Variable substitutions
+
+        Returns:
+            Tuple of (refresh_trigger, tab_update, status_message)
+        """
+        if not prompt_id:
+            return gr.update(), gr.update(), "⚠️ Please select a prompt first"
+
+        prompt_data = self.library.get_prompt(prompt_id)
+        if not prompt_data:
+            return gr.update(), gr.update(), "❌ Prompt not found"
+
+        # Substitute variables
+        final_prompt = self._substitute_variables(prompt_data["prompt"], variables)
+
+        # Update state with prompt and settings
+        if self.get_current_model_settings:
+            settings = self.get_current_model_settings(state)
+            settings["prompt"] = final_prompt
+
+            if prompt_data.get("negative_prompt"):
+                settings["negative_prompt"] = prompt_data["negative_prompt"]
+
+            # Apply saved settings
+            saved_settings = prompt_data.get("settings", {})
+            for key, value in saved_settings.items():
+                if key in settings:
+                    settings[key] = value
+
+        # Record usage
+        self.library.record_usage(prompt_id)
+
+        # Trigger form refresh and switch to video tab
+        return time.time(), gr.Tabs(selected="video_gen"), f"✅ Loaded prompt with settings: {prompt_data['name']}"
+
+    def _substitute_variables(self, prompt: str, variable_string: str) -> str:
+        """Replace {variable} placeholders with values
+
+        Args:
+            prompt: Prompt text with {placeholders}
+            variable_string: String like "key=value, key2=value2"
+
+        Returns:
+            Prompt with substituted values
+        """
+        if not variable_string or not variable_string.strip():
+            return prompt
+
+        # Parse variable string
+        variables = {}
+        for pair in variable_string.split(","):
+            pair = pair.strip()
+            if "=" in pair:
+                key, value = pair.split("=", 1)
+                variables[key.strip()] = value.strip()
+
+        # Replace {key} with value
+        for key, value in variables.items():
+            prompt = prompt.replace(f"{{{key}}}", value)
+
+        return prompt
+
+    def _show_edit_dialog(self, prompt_id: Optional[str]) -> Tuple:
+        """Show prompt details for editing
+
+        Args:
+            prompt_id: ID of prompt to edit
+
+        Returns:
+            Tuple of display values
+        """
+        if not prompt_id:
+            return "", "", "", ""
+
+        prompt_data = self.library.get_prompt(prompt_id)
+        if not prompt_data:
+            return "", "", "", ""
+
+        tags_str = ", ".join(prompt_data.get("tags", []))
+
+        return (
+            prompt_data["name"],
+            prompt_data["prompt"],
+            prompt_data.get("negative_prompt", ""),
+            tags_str
+        )
+
+    def _delete_prompt(self, prompt_id: Optional[str], collection_display: str) -> Tuple:
+        """Delete a prompt
+
+        Args:
+            prompt_id: ID of prompt to delete
+            collection_display: Current collection display name
+
+        Returns:
+            Tuple of (gallery_update, details_update, status_message)
+        """
+        if not prompt_id:
+            return gr.update(), gr.update(), "⚠️ Please select a prompt first"
+
+        prompt_data = self.library.get_prompt(prompt_id)
+        if not prompt_data:
+            return gr.update(), gr.update(), "❌ Prompt not found"
+
+        prompt_name = prompt_data["name"]
+
+        if self.library.delete_prompt(prompt_id):
+            gallery_html = self._render_prompt_gallery(collection_display)
+            return gallery_html, gr.update(visible=False), f"✅ Deleted prompt: {prompt_name}"
+        else:
+            return gr.update(), gr.update(), f"❌ Failed to delete prompt: {prompt_name}"
+
+    def _toggle_favorite(self, prompt_id: Optional[str]) -> Tuple:
+        """Toggle favorite status of a prompt
+
+        Args:
+            prompt_id: ID of prompt to toggle
+
+        Returns:
+            Tuple of (status_message, button_update)
+        """
+        if not prompt_id:
+            return "⚠️ Please select a prompt first", gr.update()
+
+        is_favorite = self.library.is_in_favorites(prompt_id)
+
+        if is_favorite:
+            if self.library.remove_from_favorites(prompt_id):
+                return "✅ Removed from favorites", gr.Button(value="☆ Favorite")
+            else:
+                return "❌ Failed to remove from favorites", gr.update()
+        else:
+            if self.library.add_to_favorites(prompt_id):
+                return "✅ Added to favorites", gr.Button(value="⭐ Unfavorite")
+            else:
+                return "❌ Failed to add to favorites", gr.update()
+
+    def _save_current_prompt(
+        self,
+        state: Dict,
+        name: str,
+        collection: str,
+        tags_str: str,
+        include_settings: bool
+    ) -> Tuple:
+        """Save current prompt to library
+
+        Args:
+            state: Application state
+            name: Name for the prompt
+            collection: Collection to save to
+            tags_str: Comma-separated tags
+            include_settings: Whether to save generation settings
+
+        Returns:
+            Tuple of (status_message, gallery_update, tag_filter_update)
+        """
+        if not name or not name.strip():
+            return "⚠️ Please provide a name for the prompt", gr.update(), gr.update()
+
+        # Get current settings
+        settings = self.get_current_model_settings(state) if self.get_current_model_settings else {}
+
+        prompt = settings.get("prompt", "")
+        if not prompt:
+            return "⚠️ No prompt to save", gr.update(), gr.update()
+
+        negative_prompt = settings.get("negative_prompt", "")
+
+        # Parse tags
+        tags = [tag.strip() for tag in tags_str.split(",") if tag.strip()]
+
+        # Capture settings if requested
+        saved_settings = {}
+        if include_settings:
+            # Save relevant generation settings
+            settings_to_save = [
+                "model_type", "resolution", "steps", "guidance_scale",
+                "num_frames", "fps", "seed", "sampler"
+            ]
+            for key in settings_to_save:
+                if key in settings:
+                    saved_settings[key] = settings[key]
+
+            # Save LoRA settings if present
+            if "loras" in settings:
+                saved_settings["loras"] = settings["loras"]
+
+        # Add prompt to library
+        prompt_id = self.library.add_prompt(
+            collection_id=collection,
+            name=name.strip(),
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            tags=tags,
+            settings=saved_settings
+        )
+
+        if prompt_id:
+            # Update gallery if we're viewing the same collection
+            gallery_update = gr.update()
+            if self.selected_collection == collection:
+                collection_display = None
+                for display, coll_id in self.library.get_collection_names():
+                    if coll_id == collection:
+                        collection_display = display
+                        break
+                if collection_display:
+                    gallery_update = self._render_prompt_gallery(collection_display)
+
+            # Update tag filter
+            tag_update = gr.Dropdown(choices=self.library.get_all_tags())
+
+            return f"✅ Saved prompt: {name}", gallery_update, tag_update
+        else:
+            return "❌ Failed to save prompt", gr.update(), gr.update()
+
+    def _create_new_collection(self) -> Tuple:
+        """Create a new collection
+
+        Returns:
+            Tuple of (radio_update, status_message)
+        """
+        # For now, return a message asking user to edit the JSON
+        # In a full implementation, this could open a dialog
+        return (
+            gr.update(),
+            "ℹ️ To create a new collection, edit the library JSON file at ~/.wan2gp/prompt_library.json"
+        )
+
+    def _delete_collection(self, collection_display: str) -> Tuple:
+        """Delete a collection
+
+        Args:
+            collection_display: Display name of collection to delete
+
+        Returns:
+            Tuple of (radio_update, gallery_update, status_message)
+        """
+        collection_id = self._extract_collection_id(collection_display)
+
+        if not collection_id:
+            return gr.update(), gr.update(), "❌ Collection not found"
+
+        if collection_id == "favorites":
+            return gr.update(), gr.update(), "⚠️ Cannot delete Favorites collection"
+
+        if self.library.delete_collection(collection_id):
+            # Update radio choices
+            new_choices = [name for name, _ in self.library.get_collection_names()]
+            radio_update = gr.Radio(choices=new_choices, value=new_choices[0] if new_choices else None)
+
+            # Update gallery
+            gallery_update = self._render_prompt_gallery(new_choices[0] if new_choices else "favorites")
+
+            return radio_update, gallery_update, f"✅ Deleted collection: {collection_display}"
+        else:
+            return gr.update(), gr.update(), f"❌ Failed to delete collection: {collection_display}"
+
+    def _import_collection(self, file_obj, merge: bool) -> Tuple:
+        """Import a collection from JSON file
+
+        Args:
+            file_obj: Uploaded file object
+            merge: Whether to merge or replace
+
+        Returns:
+            Tuple of (status_message, radio_update, gallery_update)
+        """
+        if not file_obj:
+            return "⚠️ Please select a file to import", gr.update(), gr.update()
+
+        try:
+            # Read file
+            if hasattr(file_obj, 'name'):
+                file_path = file_obj.name
+            else:
+                file_path = file_obj
+
+            with open(file_path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+
+            # Import
+            if self.library.import_collection(data, merge=merge):
+                # Update UI
+                new_choices = [name for name, _ in self.library.get_collection_names()]
+                radio_update = gr.Radio(choices=new_choices, value=new_choices[0] if new_choices else None)
+                gallery_update = self._render_prompt_gallery(new_choices[0] if new_choices else "favorites")
+
+                return "✅ Collection imported successfully", radio_update, gallery_update
+            else:
+                return "❌ Failed to import collection", gr.update(), gr.update()
+
+        except Exception as e:
+            return f"❌ Error importing collection: {str(e)}", gr.update(), gr.update()
+
+    def _export_collection(self, collection_display: str) -> str:
+        """Export a collection to JSON file
+
+        Args:
+            collection_display: Display name of collection to export
+
+        Returns:
+            Status message with download link
+        """
+        collection_id = self._extract_collection_id(collection_display)
+
+        if not collection_id:
+            return "❌ Collection not found"
+
+        export_data = self.library.export_collection(collection_id)
+        if not export_data:
+            return "❌ Failed to export collection"
+
+        # Save to file
+        output_dir = Path.home() / ".wan2gp" / "exports"
+        output_dir.mkdir(exist_ok=True)
+
+        filename = f"{collection_id}_export.json"
+        output_path = output_dir / filename
+
+        try:
+            with open(output_path, 'w', encoding='utf-8') as f:
+                json.dump(export_data, f, indent=2, ensure_ascii=False)
+
+            return f"✅ Collection exported to: {output_path}"
+        except Exception as e:
+            return f"❌ Error exporting collection: {str(e)}"
+
+    def track_prompt_usage(self, configs: Dict, **kwargs) -> Dict:
+        """Data hook - track when saved prompts are used
+
+        Args:
+            configs: Generation configs
+            **kwargs: Additional hook data
+
+        Returns:
+            Modified configs (unchanged in this case)
+        """
+        prompt = configs.get("prompt", "")
+        if prompt:
+            # Check if this matches a saved prompt
+            matching = self.library.find_by_prompt(prompt)
+            if matching:
+                self.library.record_usage(matching["id"])
+
+        return configs
+
+    def _add_custom_css(self):
+        """Add custom CSS for the prompt library UI"""
+        css = """
+        <style>
+        #prompt_library_gallery {
+            min-height: 400px;
+        }
+        </style>
+        """
+        # Note: Custom CSS would be injected via the plugin system's add_custom_js method
+        # For now, it's included in the HTML output
+
+    def on_tab_select(self, state: Dict[str, Any]) -> None:
+        """Called when the Prompt Library tab is selected
+
+        Args:
+            state: Application state
+        """
+        # Refresh library from disk in case it was modified externally
+        self.library.data = self.library._load_library()
+
+    def on_tab_deselect(self, state: Dict[str, Any]) -> None:
+        """Called when leaving the Prompt Library tab
+
+        Args:
+            state: Application state
+        """
+        # Save any pending changes
+        self.library.save_library()

--- a/plugins/wan2gp-prompt-library/requirements.txt
+++ b/plugins/wan2gp-prompt-library/requirements.txt
@@ -1,0 +1,9 @@
+# No external dependencies required
+# This plugin uses only Python standard library modules:
+# - json
+# - os
+# - pathlib
+# - datetime
+# - uuid
+# - re
+# - typing

--- a/plugins/wan2gp-prompt-library/templates.py
+++ b/plugins/wan2gp-prompt-library/templates.py
@@ -1,0 +1,223 @@
+"""
+Built-in starter templates for the prompt library
+"""
+
+from typing import Dict, List, Any
+
+
+def get_starter_templates() -> Dict[str, List[Dict[str, Any]]]:
+    """Get starter templates organized by collection
+
+    Returns:
+        Dict mapping collection_id to list of template prompts
+    """
+    return {
+        "cinematic": [
+            {
+                "name": "Epic Drone Shot",
+                "prompt": "Cinematic drone shot flying over {location}, golden hour lighting, volumetric fog, 4K quality, professional color grading, epic landscape",
+                "negative_prompt": "blurry, distorted, low quality, pixelated, amateur",
+                "tags": ["aerial", "landscape", "cinematic", "drone"],
+                "variables": ["location"],
+                "settings": {
+                    "resolution": "1280x720",
+                    "steps": 30,
+                    "guidance_scale": 7.5,
+                }
+            },
+            {
+                "name": "Slow Motion Action",
+                "prompt": "Cinematic slow motion shot of {action}, dramatic lighting, high contrast, motion blur, film grain, professional cinematography",
+                "negative_prompt": "static, boring, flat lighting, amateur",
+                "tags": ["action", "slow-motion", "cinematic"],
+                "variables": ["action"],
+                "settings": {
+                    "resolution": "1280x720",
+                    "steps": 35,
+                    "guidance_scale": 8.0,
+                }
+            },
+            {
+                "name": "Establishing Shot",
+                "prompt": "Wide establishing shot of {location}, cinematic composition, dramatic sky, professional color grading, 4K quality, film look",
+                "negative_prompt": "blurry, amateur, poor composition, oversaturated",
+                "tags": ["wide-shot", "establishing", "cinematic", "landscape"],
+                "variables": ["location"],
+                "settings": {
+                    "resolution": "1280x720",
+                    "steps": 30,
+                    "guidance_scale": 7.5,
+                }
+            },
+            {
+                "name": "Close-up Portrait",
+                "prompt": "Cinematic close-up portrait of {subject}, shallow depth of field, professional lighting, film grain, emotional expression, 4K quality",
+                "negative_prompt": "blurry, distorted face, bad anatomy, oversaturated",
+                "tags": ["portrait", "close-up", "cinematic", "character"],
+                "variables": ["subject"],
+                "settings": {
+                    "resolution": "1280x720",
+                    "steps": 35,
+                    "guidance_scale": 8.0,
+                }
+            }
+        ],
+        "anime": [
+            {
+                "name": "Anime Character Action",
+                "prompt": "Anime style, {character} performing {action}, dynamic pose, vibrant colors, detailed animation, studio quality, clean lines",
+                "negative_prompt": "blurry, poorly drawn, distorted anatomy, low quality",
+                "tags": ["anime", "character", "action", "dynamic"],
+                "variables": ["character", "action"],
+                "settings": {
+                    "resolution": "1280x720",
+                    "steps": 30,
+                    "guidance_scale": 7.5,
+                }
+            },
+            {
+                "name": "Anime Background Scene",
+                "prompt": "Anime background art, {location}, detailed scenery, soft lighting, pastel colors, studio ghibli style, atmospheric",
+                "negative_prompt": "blurry, low detail, poor composition, distorted",
+                "tags": ["anime", "background", "scenery", "ghibli"],
+                "variables": ["location"],
+                "settings": {
+                    "resolution": "1280x720",
+                    "steps": 30,
+                    "guidance_scale": 7.5,
+                }
+            },
+            {
+                "name": "Magical Girl Transformation",
+                "prompt": "Magical girl transformation sequence, {character}, sparkles and ribbons, vibrant colors, dynamic camera movement, anime style, high quality animation",
+                "negative_prompt": "static, boring, low quality, distorted",
+                "tags": ["anime", "magical-girl", "transformation", "dynamic"],
+                "variables": ["character"],
+                "settings": {
+                    "resolution": "1280x720",
+                    "steps": 35,
+                    "guidance_scale": 8.0,
+                }
+            }
+        ],
+        "realistic": [
+            {
+                "name": "Nature Documentary",
+                "prompt": "Nature documentary style, {subject} in natural habitat, photorealistic, professional wildlife cinematography, 4K quality, natural lighting",
+                "negative_prompt": "artificial, staged, low quality, blurry, distorted",
+                "tags": ["nature", "documentary", "wildlife", "realistic"],
+                "variables": ["subject"],
+                "settings": {
+                    "resolution": "1280x720",
+                    "steps": 35,
+                    "guidance_scale": 8.0,
+                }
+            },
+            {
+                "name": "Urban Street Scene",
+                "prompt": "Photorealistic urban street scene, {location}, natural lighting, people walking, modern city, 4K quality, professional cinematography",
+                "negative_prompt": "artificial, cartoonish, low quality, distorted",
+                "tags": ["urban", "street", "realistic", "city"],
+                "variables": ["location"],
+                "settings": {
+                    "resolution": "1280x720",
+                    "steps": 35,
+                    "guidance_scale": 8.0,
+                }
+            },
+            {
+                "name": "Product Showcase",
+                "prompt": "Professional product video, {product}, rotating 360 degrees, studio lighting, clean background, commercial quality, 4K resolution",
+                "negative_prompt": "amateur, poor lighting, cluttered, low quality",
+                "tags": ["product", "commercial", "studio", "realistic"],
+                "variables": ["product"],
+                "settings": {
+                    "resolution": "1280x720",
+                    "steps": 30,
+                    "guidance_scale": 7.5,
+                }
+            },
+            {
+                "name": "Time Lapse Scene",
+                "prompt": "Time lapse of {scene}, photorealistic, smooth motion, dramatic lighting changes, professional quality, 4K resolution",
+                "negative_prompt": "choppy, low quality, artificial, blurry",
+                "tags": ["time-lapse", "realistic", "dramatic"],
+                "variables": ["scene"],
+                "settings": {
+                    "resolution": "1280x720",
+                    "steps": 30,
+                    "guidance_scale": 7.5,
+                }
+            }
+        ],
+        "character": [
+            {
+                "name": "Character Walk Cycle",
+                "prompt": "{character} walking towards camera, full body shot, smooth animation, consistent movement, professional quality, clear details",
+                "negative_prompt": "jerky motion, distorted anatomy, inconsistent, blurry",
+                "tags": ["character", "walk", "animation", "full-body"],
+                "variables": ["character"],
+                "settings": {
+                    "resolution": "1280x720",
+                    "steps": 35,
+                    "guidance_scale": 8.0,
+                }
+            },
+            {
+                "name": "Character Talking",
+                "prompt": "Close-up of {character} talking, natural lip sync, expressive face, subtle movements, professional animation quality",
+                "negative_prompt": "frozen face, poor lip sync, distorted, unnatural",
+                "tags": ["character", "talking", "close-up", "expression"],
+                "variables": ["character"],
+                "settings": {
+                    "resolution": "1280x720",
+                    "steps": 35,
+                    "guidance_scale": 8.0,
+                }
+            },
+            {
+                "name": "Character Emotion",
+                "prompt": "{character} expressing {emotion}, facial close-up, subtle movements, natural expression, professional quality, detailed animation",
+                "negative_prompt": "frozen face, unnatural, distorted, poor animation",
+                "tags": ["character", "emotion", "expression", "close-up"],
+                "variables": ["character", "emotion"],
+                "settings": {
+                    "resolution": "1280x720",
+                    "steps": 35,
+                    "guidance_scale": 8.0,
+                }
+            },
+            {
+                "name": "Character Action Sequence",
+                "prompt": "{character} performing {action}, dynamic movement, smooth animation, action choreography, professional quality",
+                "negative_prompt": "static, jerky, poor animation, distorted",
+                "tags": ["character", "action", "dynamic", "animation"],
+                "variables": ["character", "action"],
+                "settings": {
+                    "resolution": "1280x720",
+                    "steps": 35,
+                    "guidance_scale": 8.0,
+                }
+            }
+        ]
+    }
+
+
+def initialize_library_with_templates(library):
+    """Initialize a library with starter templates
+
+    Args:
+        library: PromptLibrary instance to populate
+    """
+    templates = get_starter_templates()
+
+    for collection_id, prompts in templates.items():
+        for prompt_data in prompts:
+            library.add_prompt(
+                collection_id=collection_id,
+                name=prompt_data["name"],
+                prompt=prompt_data["prompt"],
+                negative_prompt=prompt_data.get("negative_prompt", ""),
+                tags=prompt_data.get("tags", []),
+                settings=prompt_data.get("settings", {})
+            )


### PR DESCRIPTION
Implemented a comprehensive prompt management system with the following features:

- Save and organize prompts in collections (Favorites, Cinematic, Anime, Realistic, Character)
- Search and filter prompts by name, text, or tags
- Variable substitution system with {placeholder} support
- Save/restore generation settings with prompts (model, resolution, LoRAs, etc.)
- Favorites system for quick access to best prompts
- Usage tracking to identify most-used prompts
- Import/Export functionality for sharing collections
- Pre-loaded starter templates for each collection

Plugin structure:
- __init__.py: Plugin entry point
- plugin.py: Main plugin class with Gradio UI
- library.py: Data persistence and retrieval logic
- templates.py: Built-in starter templates
- requirements.txt: Dependencies (none required)
- README.md: Complete documentation

Data is stored in ~/.wan2gp/prompt_library.json

The plugin integrates with Wan2GP's plugin system and can be enabled through the Plugin Manager or by adding "wan2gp-prompt-library" to the enabled_plugins list in server config.