### PR TITLE
Fix TypeError: object of type 'PngImageFile' has no len() in wgp.py

### DIFF
--- a/wgp.py
+++ b/wgp.py
@@ -573,7 +573,9 @@ def validate_settings(state, model_type, single_prompt, inputs):
     width, height = resolution.split("x")
     width, height = int(width), int(height)
     image_start = inputs["image_start"]
+    if image_start is not None and not isinstance(image_start, list): image_start = [image_start]
     image_end = inputs["image_end"]
+    if image_end is not None and not isinstance(image_end, list): image_end = [image_end]
     image_refs = inputs["image_refs"]
     image_prompt_type = inputs["image_prompt_type"]
     audio_prompt_type = inputs["audio_prompt_type"]


### PR DESCRIPTION
Description:
  I encountered a crash when processing a queue where image_start was a single image. The error was:
  TypeError: object of type 'PngImageFile' has no len()

  The Cause:
  The validate_settings function in wgp.py expects image_start (and image_end) to be lists so it can check their length
  (e.g., len(image_start)). However, the queue loader sometimes passes them as single PIL.Image objects, causing len()
  to fail.

  The Fix:
  I resolved this by ensuring these variables are always wrapped in a list immediately after they are retrieved from
  inputs.