### PR TITLE
Update FlashVSR version to 1.0.2

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -30,7 +30,7 @@
   {
     "name": "FlashVSR",
     "author": "Hakaze",
-    "version": "1.0.0",
+    "version": "1.0.2",
     "description": "AI-powered 4x video upscaling using FlashVSR models with Sparse SageAttention.",
     "url": "https://github.com/Hakaze/wan2gp-flashvsr.git"
   }


### PR DESCRIPTION
## [1.0.2] - 2025-12-29

### Fixed

- **Output Video Quality = 10 produced audio-only files** - Updated MP4 encoding to use explicit H.264 settings (libx264 + yuv420p) and a stable quality→CRF mapping for reliable video streams.

### Housekeeping
- Fixed some incorrect links and formatting issues in `README` and `TROUBLESHOOTING`.

[1.0.2]: https://github.com/Hakaze/wan2gp-flashvsr/releases/tag/v1.0.2

## [1.0.1] - 2025-12-23

### Added

- **Pre-Flight Resource Check** - Estimates VRAM/RAM requirements before processing starts
  - Uses SAFETY_FACTOR of 4.0 for accurate estimation (based on ComfyUI-FlashVSR_Stable)
  - Displays warnings with recommended settings when resources are insufficient
  - Logs processing summary with peak VRAM usage on completion
- **Cancellation Support** - Stop button to cancel long-running upscaling operations
  - Two-button pattern: Upscale button hides, Stop button appears during processing
  - Graceful cancellation with cleanup of partial files
  - Note: Cannot interrupt mid-inference; stops between operations
- **Adaptive Batch Sizing** - Dynamically calculates safe batch sizes based on available RAM
  - Queries system RAM at runtime using `psutil`
  - Prevents memory exhaustion during video output phase

### Changed

- **Memory-Efficient Video Output** - Streaming frame writer replaces batch-to-numpy conversion
  - Eliminates 10-15GB+ RAM spike during 4K output
  - Progressive cleanup of intermediate tensors
- **Improved Tiled DiT Guidance** - UI now recommends Tiled DiT for 50+ frame videos
  - Updated info text explaining O(n²) complexity without tiling
  - Pre-flight warns when >100 frames without Tiled DiT enabled
- **Status Feedback** - Replaced status textbox with Gradio toast notifications
  - `gr.Info` for success messages
  - `gr.Warning` for warnings and recommendations  
  - `gr.Error` for error messages

### Fixed

- **Memory Exhaustion on 4x Upscale** - 100+ frame 4K videos no longer cause system lockups
- **No Way to Cancel** - Users can now stop processing (between operations)

[1.0.1]: https://github.com/Hakaze/wan2gp-flashvsr/releases/tag/v1.0.1