### PR TITLE
Fix InvalidPath Error

### DIFF
--- a/wgp.py
+++ b/wgp.py
@@ -3713,6 +3713,26 @@ def unpack_audio_list(packed_audio_file_list):
 def refresh_gallery(state): #, msg
     gen = get_gen_info(state)
 
+    for list_key, settings_key, sel_key in [("file_list", "file_settings_list", "selected"), ("audio_file_list", "audio_file_settings_list", "audio_selected")]:
+        f_list = gen.get(list_key)
+        if f_list:
+            s_list = gen.get(settings_key, [])
+            new_f, new_s = [], []
+            changed = False
+            for i, f in enumerate(f_list):
+                if os.path.exists(f):
+                    new_f.append(f)
+                    new_s.append(s_list[i] if i < len(s_list) else None)
+                else:
+                    changed = True
+            
+            if changed:
+                gen[list_key] = new_f
+                gen[settings_key] = new_s
+                current_sel = gen.get(sel_key, 0)
+                if current_sel >= len(new_f):
+                    gen[sel_key] = max(0, len(new_f) - 1)
+
     # gen["last_msg"] = msg
     file_list = gen.get("file_list", None)      
     choice = gen.get("selected",0)
@@ -3968,6 +3988,9 @@ def select_video(state, current_gallery_tab, input_file_list, file_selected, aud
             pass 
         configs = settings_list[choice]
         file_name = files[choice]
+        if not os.path.exists(file_name):
+             visible = False
+             return choice if source=="video" else gr.update(), get_default_video_info(), gr.update(visible=visible) , gr.update(visible=visible), gr.update(visible=visible), gr.update(visible=visible) , gr.update(visible=visible) 
         values = [  os.path.basename(file_name)]
         labels = [ "File Name"]
         misc_values= []


### PR DESCRIPTION
Was getting sick of this invalidpath error we've had for over a year that happens when you delete a file in your output folder during generation:

```
Traceback (most recent call last):
File "C:\Users\chris\AppData\Local\WAN2GP\venv\Lib\site-packages\gradio\queueing.py", line 625, in process_events
response = await route_utils.call_process_api(
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "C:\Users\chris\AppData\Local\WAN2GP\venv\Lib\site-packages\gradio\route_utils.py", line 322, in call_process_api
output = await app.get_blocks().process_api(
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "C:\Users\chris\AppData\Local\WAN2GP\venv\Lib\site-packages\gradio\blocks.py", line 2142, in process_api
inputs = await self.preprocess_data(
^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "C:\Users\chris\AppData\Local\WAN2GP\venv\Lib\site-packages\gradio\blocks.py", line 1796, in preprocess_data
inputs_cached = await processing_utils.async_move_files_to_cache(
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "C:\Users\chris\AppData\Local\WAN2GP\venv\Lib\site-packages\gradio\processing_utils.py", line 648, in async_move_files_to_cache
return await client_utils.async_traverse(
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "C:\Users\chris\AppData\Local\WAN2GP\venv\Lib\site-packages\gradio_client\utils.py", line 1138, in async_traverse
new_obj.append(await async_traverse(item, func, is_root))
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "C:\Users\chris\AppData\Local\WAN2GP\venv\Lib\site-packages\gradio_client\utils.py", line 1133, in async_traverse
new_obj[key] = await async_traverse(value, func, is_root)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "C:\Users\chris\AppData\Local\WAN2GP\venv\Lib\site-packages\gradio_client\utils.py", line 1129, in async_traverse
return await func(json_obj)
^^^^^^^^^^^^^^^^^^^^
File "C:\Users\chris\AppData\Local\WAN2GP\venv\Lib\site-packages\gradio\processing_utils.py", line 619, in _move_to_cache
_check_allowed(payload.path, check_in_upload_folder)
File "C:\Users\chris\AppData\Local\WAN2GP\venv\Lib\site-packages\gradio\processing_utils.py", line 564, in _check_allowed
raise InvalidPathError(msg)
gradio.exceptions.InvalidPathError: Cannot move E:\Downloads\stablediffusion_archive\WAN\gradio_outputs\2026-01-26-21h27m39s_seed20787742_test.mp4 to the gradio cache dir because it was not uploaded by a user.
```
As well as this new one we now have:
```
Traceback (most recent call last):
File "C:\Users\chris\AppData\Local\WAN2GP\venv\Lib\site-packages\gradio\queueing.py", line 625, in process_events
response = await route_utils.call_process_api(
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "C:\Users\chris\AppData\Local\WAN2GP\venv\Lib\site-packages\gradio\route_utils.py", line 322, in call_process_api
output = await app.get_blocks().process_api(
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "C:\Users\chris\AppData\Local\WAN2GP\venv\Lib\site-packages\gradio\blocks.py", line 2146, in process_api
result = await self.call_function(
^^^^^^^^^^^^^^^^^^^^^^^^^
File "C:\Users\chris\AppData\Local\WAN2GP\venv\Lib\site-packages\gradio\blocks.py", line 1664, in call_function
prediction = await anyio.to_thread.run_sync(  # type: ignore
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "C:\Users\chris\AppData\Local\WAN2GP\venv\Lib\site-packages\anyio\to_thread.py", line 61, in run_sync
return await get_async_backend().run_sync_in_worker_thread(
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "C:\Users\chris\AppData\Local\WAN2GP\venv\Lib\site-packages\anyio_backends_asyncio.py", line 2525, in run_sync_in_worker_thread
return await future
^^^^^^^^^^^^
File "C:\Users\chris\AppData\Local\WAN2GP\venv\Lib\site-packages\anyio_backends_asyncio.py", line 986, in run
result = context.run(func, *args)
^^^^^^^^^^^^^^^^^^^^^^^^
File "C:\Users\chris\AppData\Local\WAN2GP\venv\Lib\site-packages\gradio\utils.py", line 884, in wrapper
response = f(*args, **kwargs)
^^^^^^^^^^^^^^^^^^
File "C:\Users\chris\AppData\Local\WAN2GP\wgp.py", line 3834, in select_video
nb_audio_tracks = extract_audio_tracks(file_name,query_only = True)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "C:\Users\chris\AppData\Local\WAN2GP\shared\utils\audio_video.py", line 41, in extract_audio_tracks
raise FileNotFoundError(msg)
FileNotFoundError: ffprobe skipped; file not found: E:\Downloads\stablediffusion_archive\WAN\gradio_outputs\2026-01-26-21h27m39s_seed20787742_test.mp4
```

When this error occurs, it crashes the server entirely and you lose your queue.
A fix for the first problem was attempted back at #980 and #987, but it was messy and didn't seem to work.
This one solves both problems with minimal changes.