### PR TITLE
Add safe mode to prevent plugins crashing startup

### DIFF
--- a/wgp.py
+++ b/wgp.py
@@ -11330,6 +11330,33 @@ if __name__ == "__main__":
 
     # Normal Gradio mode continues below...
     atexit.register(autosave_queue)
+
+    STARTUP_LOCK_FILE = "startup.lock"
+    globals()["SAFE_MODE"] = False
+
+    if os.path.exists(STARTUP_LOCK_FILE):
+        print("\n" + "!"*10)
+        print("DETECTED FAILED PREVIOUS STARTUP. ENTERING SAFE MODE.")
+        print("All user plugins are disabled to allow the server to start.")
+        print("!"*10 + "\n")
+        globals()["SAFE_MODE"] = True
+
+    try:
+        with open(STARTUP_LOCK_FILE, "w") as f:
+            f.write(str(time.time()))
+    except Exception as e:
+        print(f"Warning: Could not create startup lock file: {e}")
+
+    def mark_startup_success():
+        time.sleep(30)
+        if os.path.exists(STARTUP_LOCK_FILE):
+            try:
+                os.remove(STARTUP_LOCK_FILE)
+            except:
+                pass
+
+    threading.Thread(target=mark_startup_success, daemon=True).start()
+
     download_ffmpeg()
     # threading.Thread(target=runner, daemon=True).start()
     os.environ["GRADIO_ANALYTICS_ENABLED"] = "False"


### PR DESCRIPTION
As mentioned at #1426, we need a way for startup to continue if plugins crash.
This will make it so that if a plugin crashes, the next time you start will be in safe mode (all user plugins disabled).
There, you can remove problematic ones, restart and see if the problem is fixed, or generate without using plugins.

Ideally, this would be done without creating a startup.lock file which creates extra hdd read/writes every startup, but I can't think of a better way yet.
This is probably better to have in the meantime anyway, as the alternative is breaking WAN2GP altogether simply by installing a broken plugin.