### PR TITLE
Allow dragging over top and bottom queue buttons, moved top and bottom buttons to top and bottom of queue

### DIFF
--- a/wgp.py
+++ b/wgp.py
@@ -1573,22 +1573,35 @@ def generate_queue_html(queue):
     if len(queue) <= 1:
         return "<div style='text-align: center; color: grey; padding: 20px;'>Queue is empty.</div>"
 
-    scroll_buttons = ""
+    top_button_html = ""
+    bottom_button_html = ""
+    
     if len(queue) > 11:
-        scroll_buttons = """
-        <div style="display: flex; justify-content: flex-end; gap: 8px; margin-bottom: 8px;">
-            <div>
-                <button onclick="scrollToQueueTop()" class="gr-button gr-button-sm gr-button-secondary" style="display: flex; align-items: center;">
-                    <img src="/gradio_api/file=icons/top.svg" alt="Top" style="width: 1.1em; height: 1.1em; margin-right: 4px;">
-                    Top
-                </button>
-            </div>
-            <div>
-                <button onclick="scrollToQueueBottom()" class="gr-button gr-button-sm gr-button-secondary" style="display: flex; align-items: center;">
-                    <img src="/gradio_api/file=icons/bottom.svg" alt="Bottom" style="width: 1.1em; height: 1.1em; margin-right: 4px;">
-                    Bottom
-                </button>
-            </div>
+        btn_style = "width: 100%; padding: 8px; margin-bottom: 2px; font-weight: bold; display: flex; justify-content: center; align-items: center;"
+        
+        top_button_html = f"""
+        <div style="margin-bottom: 5px;">
+            <button onclick="scrollToQueueTop()" 
+                    ondragenter="scrollToQueueTop(); event.preventDefault();" 
+                    ondragover="event.preventDefault();"
+                    class="gr-button gr-button-secondary" 
+                    style="{btn_style}">
+                <img src="/gradio_api/file=icons/top.svg" alt="Top" style="width: 1.3em; height: 1.3em; margin-right: 6px;">
+                Scroll to Top
+            </button>
+        </div>
+        """
+        
+        bottom_button_html = f"""
+        <div style="margin-top: 5px;">
+            <button onclick="scrollToQueueBottom()" 
+                    ondragenter="scrollToQueueBottom(); event.preventDefault();" 
+                    ondragover="event.preventDefault();"
+                    class="gr-button gr-button-secondary" 
+                    style="{btn_style.replace('margin-bottom', 'margin-top')}">
+                <img src="/gradio_api/file=icons/bottom.svg" alt="Bottom" style="width: 1.3em; height: 1.3em; margin-right: 6px;">
+                Scroll to Bottom
+            </button>
         </div>
         """
 
@@ -1674,7 +1687,7 @@ def generate_queue_html(queue):
     table_html = table_header + "".join(table_rows) + table_footer
     scrollable_div = f'<div id="queue-scroll-container" style="max-height: 650px; overflow-y: auto;">{table_html}</div>'
 
-    return scroll_buttons + scrollable_div
+    return top_button_html + scrollable_div + bottom_button_html
 
 def update_queue_data(queue):
     update_global_queue_ref(queue)


### PR DESCRIPTION
Another simple fix that should be an easy clean merge.
Often when rearranging queue items, things will be really far down or up, and you just have to wait ages for it to scroll. This allows you to snap scroll to bottom or top while dragging queue items.