### PR TITLE
move clear_startup_lock to quit_application

### DIFF
--- a/wgp.py
+++ b/wgp.py
@@ -1523,6 +1523,7 @@ def clear_queue_action(state):
 
 def quit_application():
     print("Save and Quit requested...")
+    clear_startup_lock()
     autosave_queue()
     import signal
     os.kill(os.getpid(), signal.SIGINT)
@@ -1540,7 +1541,6 @@ def show_countdown_info_from_state(current_value: int):
     return current_value
 quitting_app = False
 def autosave_queue():
-    clear_startup_lock()
     global quitting_app
     quitting_app = True
     global global_queue_ref


### PR DESCRIPTION
Been trying to get my training plugin working again and caused it to crash on startup in a different way.
Safe mode didn't work when I started up again.

clear_startup_lock() should have been in quit_application(), not start_quit_process() which still gets fired on some crashes.