### PR TITLE
Fix misleading KugelAudio description ('Speaker 0:' instead of 'Speaker0:' etc)

### DIFF
--- a/defaults/kugelaudio_0_open.json
+++ b/defaults/kugelaudio_0_open.json
@@ -2,7 +2,7 @@
     "model": {
         "name": "TTS KugelAudio 0 Open 7B",
         "architecture": "kugelaudio_0_open",
-        "description": "KugelAudio open-source text-to-speech with optional voice cloning, based on an AR + diffusion architecture. You can create a dialogue between two people by providing two audio sources and by starting lines alternatively with'Speaker0: ' or 'Speaker1: '.",
+        "description": "KugelAudio open-source text-to-speech with optional voice cloning, based on an AR + diffusion architecture. You can create a dialogue between two people by providing two audio sources and by starting lines alternatively with 'Speaker 0: ' or 'Speaker 1: '.",
         "URLs": [
             "https://huggingface.co/DeepBeepMeep/TTS/resolve/main/kugelaudio_0_open_bf16.safetensors",
             "https://huggingface.co/DeepBeepMeep/TTS/resolve/main/kugelaudio_0_open_quanto_bf16_int8.safetensors"


### PR DESCRIPTION
When entering `Speaker0: ` in the prompt input, validation failed, while `Speaker 0: ` was accepted, so the model description was corrected to match the actual validator behavior.