### PR TITLE
Queue Notifications for Wan2GP (Telegram, Discord, WhatsApp, IFTTT, Google Chat)

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -70,5 +70,18 @@
     "url": "https://github.com/Tophness/wan2gp-queue-editor",
     "date": "",
     "wan2gp_version": ""
+  },
+  {
+    "name": "Video queue notifications",
+    "author": "Javier-bat",
+    "version": "1.1.0",
+    "description": "Logs queue task status and can send notifications via Apprise.",
+    "url": "https://github.com/Javier-bat/wan2gp-notifier",
+    "date": "",
+    "wan2gp_version": ""
   }
+
+
+  
+
 ]


### PR DESCRIPTION
# wan2gp-notifier

Plugin that logs queue task status and can send notifications via Apprise.

## Features

- Queue completion/failure console logs
- Apprise notification delivery
- UI tab (`Notifier`) to:
  - enable/disable notifications
  - choose provider (`telegram`, `discord`, `whatsapp`, `ifttt`, `google_chat`)
  - save and test notification config
<img width="461" height="343" alt="image" src="https://github.com/user-attachments/assets/60e7d883-9699-49fa-b5a7-05a50f8e2560" />
<img width="413" height="316" alt="image" src="https://github.com/user-attachments/assets/8739086a-1626-468b-83be-f209aff86162" />
