### PR TITLE
fix: zero-initialize KV cache to prevent NaN in fallback attention

### DIFF
--- a/shared/llm_engines/nanovllm/engine/model_runner.py
+++ b/shared/llm_engines/nanovllm/engine/model_runner.py
@@ -492,7 +492,7 @@ class ModelRunner:
                 f"Requested max_model_len={config.max_model_len}, max_num_seqs={config.max_num_seqs}."
             )
         try:
-            self.kv_cache = torch.empty(
+            self.kv_cache = torch.zeros(
                 2,
                 hf_config.num_hidden_layers,
                 config.num_kvcache_blocks,


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary

- `torch.empty()` leaves uninitialized GPU memory in KV cache slots that are never written (e.g. the tail of the last block when a sequence doesn't fill it completely)
- `_flash_attention_fallback_decode` reads all allocated blocks and masks invalid positions with `-inf` in the attention bias
- **Bug**: `NaN + (-inf) = NaN`, not `-inf` — so when uninitialized slots contain NaN/Inf, the masking fails and NaN propagates through softmax, corrupting the entire attention output
- Switching to `torch.zeros()` ensures unwritten slots contain `0`: `0 + (-inf) = -inf` → softmax weight = 0 → no contamination

This fixes garbage output (e.g. `"A!!!..."`) from Qwen TI mode image captioning via the vLLM embedded prefill/decode path. The bug was non-deterministic: it only manifested when `torch.empty()` happened to place NaN/Inf in the uninitialized tail of a specific layer's cache (in practice, always model layer 23 / attention layer_idx 5 in the 9B hybrid model).

## Test plan

- [ ] Run prompt enhancer in TI (text + image) mode with an image input and verify captions are coherent instead of garbage
- [ ] Verify T-only mode prompt enhancement still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)