### PR TITLE
fix: ScaledFP8WeightTensor crashes on detach/to when inner tensors are inference tensors

### DIFF
--- a/shared/qtypes/scaled_fp8.py
+++ b/shared/qtypes/scaled_fp8.py
@@ -409,6 +409,31 @@ class ScaledFP8WeightTensor(QTensor):
             bias = args[2] if len(args) > 2 else kwargs.get("bias", None)
             if isinstance(weight, ScaledFP8WeightTensor):
                 return weight.linear(input, bias=bias)
+        # torch.Tensor.to() on an inference ScaledFP8WeightTensor fails in C++ with
+        # "Cannot set version_counter for inference tensor" because __torch_dispatch__
+        # is bypassed for inference tensors. Handle it here before reaching C++.
+        if func is torch.Tensor.to:
+            t = args[0] if args else None
+            if isinstance(t, ScaledFP8WeightTensor):
+                kw = dict(kwargs)
+                device = kw.pop("device", t.device)
+                dtype = kw.pop("dtype", t.dtype)
+                kw.pop("copy", None)  # always creating a new tensor, flag is redundant
+                if isinstance(device, str):
+                    device = torch.device(device)
+                if dtype != t.dtype:
+                    return t.dequantize(dtype=dtype, device=device)
+                with torch.inference_mode(False):
+                    out_data = t._data.to(device=device, **kw)
+                    out_scale = t._scale.to(device=device, **kw)
+                return ScaledFP8WeightTensor.create(
+                    weight=out_data,
+                    scale=out_scale,
+                    size=t.size(),
+                    stride=t.stride(),
+                    dtype=t.dtype,
+                    device=device,
+                )
         with torch._C.DisableTorchFunctionSubclass():
             return func(*args, **kwargs)
 
@@ -437,7 +462,6 @@ class ScaledFP8WeightTensor(QTensor):
             t = args[0]
             dtype = kwargs.pop("dtype", t.dtype) if kwargs else t.dtype
             device = kwargs.pop("device", t.device) if kwargs else t.device
-            kwargs.pop("copy", None)  # copy=True on inference tensors raises version_counter error
             if dtype != t.dtype:
                 return t.dequantize(dtype=dtype, device=device)
             out_data = op(t._data, device=device, **(kwargs or {}))

--- a/shared/qtypes/scaled_fp8.py
+++ b/shared/qtypes/scaled_fp8.py
@@ -409,12 +409,28 @@ class ScaledFP8WeightTensor(QTensor):
             bias = args[2] if len(args) > 2 else kwargs.get("bias", None)
             if isinstance(weight, ScaledFP8WeightTensor):
                 return weight.linear(input, bias=bias)
-        # torch.Tensor.to() on an inference ScaledFP8WeightTensor fails in C++ with
-        # "Cannot set version_counter for inference tensor" because __torch_dispatch__
-        # is bypassed for inference tensors. Handle it here before reaching C++.
-        if func is torch.Tensor.to:
-            t = args[0] if args else None
-            if isinstance(t, ScaledFP8WeightTensor):
+        # detach() and to() on a ScaledFP8WeightTensor whose inner _data/_scale are
+        # inference tensors fail deep in C++ with "Cannot set version_counter for
+        # inference tensor". The func received here is the C-level TensorBase method
+        # (not torch.Tensor.detach / torch.Tensor.to), so we match by name.
+        # Handle both ops before they reach C++ dispatch.
+        func_name = getattr(func, "__name__", None)
+        t = args[0] if args else None
+        if isinstance(t, ScaledFP8WeightTensor):
+            if func_name == "detach":
+                # Return a new wrapper sharing the same inner tensors (no-op detach).
+                # Calling op(t._data) on an inference _data would try to set version
+                # counters → error. Model weights don't need grad so sharing is safe.
+                return ScaledFP8WeightTensor.create(
+                    weight=t._data,
+                    scale=t._scale,
+                    size=t.size(),
+                    stride=t.stride(),
+                    dtype=t.dtype,
+                    device=t.device,
+                    requires_grad=False,
+                )
+            if func_name == "to":
                 kw = dict(kwargs)
                 device = kw.pop("device", t.device)
                 dtype = kw.pop("dtype", t.dtype)
@@ -449,14 +465,18 @@ class ScaledFP8WeightTensor(QTensor):
                 return weight.linear(input, bias=bias)
         if op is torch.ops.aten.detach:
             t = args[0]
+            # Do NOT call op(t._data) / op(t._scale): if the inner tensors are
+            # inference tensors, aten::detach tries to set up version-counter sharing
+            # and raises "Cannot set version_counter for inference tensor".
+            # Model weights never require grad, so sharing inner tensors is safe.
             return ScaledFP8WeightTensor.create(
-                weight=op(t._data),
-                scale=op(t._scale),
+                weight=t._data,
+                scale=t._scale,
                 size=t.size(),
                 stride=t.stride(),
                 dtype=t.dtype,
                 device=t.device,
-                requires_grad=t.requires_grad,
+                requires_grad=False,
             )
         if op in (torch.ops.aten._to_copy, torch.ops.aten.to):
             t = args[0]

--- a/shared/qtypes/scaled_fp8.py
+++ b/shared/qtypes/scaled_fp8.py
@@ -287,12 +287,13 @@ class ScaledFP8WeightTensor(QTensor):
         qweight= self
         target_type = _normalize_default_dtype(qweight.dtype)
         weights, output_scales = qweight._data, qweight._scale
+        target_device = input.device
         input = input.to(target_type)
-        output_scales = output_scales.to(target_type)
+        output_scales = output_scales.to(device=target_device, dtype=target_type)
         in_features = input.shape[-1]
         out_features = weights.shape[0]
         output_shape = input.shape[:-1] + (out_features,)
-        weights = weights.to(target_type)
+        weights = weights.to(device=target_device, dtype=target_type)
         weights *= output_scales
         out = torch.matmul(input.reshape(-1, in_features), weights.t())
         out = out.reshape(output_shape)

--- a/shared/qtypes/scaled_fp8.py
+++ b/shared/qtypes/scaled_fp8.py
@@ -437,6 +437,7 @@ class ScaledFP8WeightTensor(QTensor):
             t = args[0]
             dtype = kwargs.pop("dtype", t.dtype) if kwargs else t.dtype
             device = kwargs.pop("device", t.device) if kwargs else t.device
+            kwargs.pop("copy", None)  # copy=True on inference tensors raises version_counter error
             if dtype != t.dtype:
                 return t.dequantize(dtype=dtype, device=device)
             out_data = op(t._data, device=device, **(kwargs or {}))

--- a/shared/qtypes/scaled_fp8.py
+++ b/shared/qtypes/scaled_fp8.py
@@ -485,8 +485,9 @@ class ScaledFP8WeightTensor(QTensor):
             device = kwargs.pop("device", t.device) if kwargs else t.device
             if dtype != t.dtype:
                 return t.dequantize(dtype=dtype, device=device)
-            out_data = op(t._data, device=device, **(kwargs or {}))
-            out_scale = op(t._scale, device=device, **(kwargs or {}))
+            with torch.inference_mode(False):
+                out_data = op(t._data, device=device, **(kwargs or {}))
+                out_scale = op(t._scale, device=device, **(kwargs or {}))
             return ScaledFP8WeightTensor.create(
                 weight=out_data,
                 scale=out_scale,


### PR DESCRIPTION
I created this PR to be able to run a fine-tuned LTX2.3 Dev model that's only available as FP8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Problem

Running FP8-quantized checkpoints (e.g. LTX-2.3 22B) crashes with:

```
RuntimeError: Cannot set version_counter for inference tensor
```

The crash occurs in `ScaledFP8WeightTensor.__torch_function__` when LTX-2's `_duplicate_timestep_embedder` calls `.detach().to(device)` on a quantized weight during the prewarm step. A secondary crash follows in `_linear_fallback`:

```
RuntimeError: Expected all tensors to be on the same device
```

## Root cause

`ScaledFP8WeightTensor` is a `_make_wrapper_subclass` tensor whose inner `_data` (fp8) and `_scale` (float32) tensors are created as **inference tensors** during model loading (under `torch.inference_mode()`). The wrapper itself is not an inference tensor, but its inner tensors are.

When `.detach()` is called on the wrapper, PyTorch attempts to set up version-counter sharing on the inner tensors — which is illegal for inference tensors. Two dispatch layers were affected:

1. **`__torch_function__`**: receives the C-level `TensorBase.detach` method (not `torch.Tensor.detach`), so identity checks fail. Must match by `func.__name__`.
2. **`__torch_dispatch__`**: the existing `aten.detach` handler called `op(t._data)` directly, which triggers the same version-counter error.
3. **`__torch_dispatch__` `_to_copy`**: same issue — called `op(t._data)` without guarding against inference tensors.

The `_linear_fallback` device mismatch was a separate latent bug: the fallback path converted weights to the right dtype but forgot to move them to the right device, only surfacing when the fallback was actually exercised.

## Fix

- **`__torch_function__`**: intercept `detach` and `to` by name before they reach C++ dispatch. For `detach`, return a new wrapper sharing the same inner tensors (safe — model weights never require grad). For `to`, use `torch.inference_mode(False)` to move inner tensors without version-counter errors.
- **`__torch_dispatch__` `detach`**: stop calling `op(t._data)` / `op(t._scale)`; share inner tensors directly instead.
- **`__torch_dispatch__` `_to_copy`**: wrap `op(t._data)` / `op(t._scale)` in `torch.inference_mode(False)` for consistency with the `__torch_function__` path.
- **`_linear_fallback`**: capture `target_device = input.device` and pass it to both `.to()` calls so weights land on the correct device.

## Why this only surfaces with FP8 checkpoints

The bug requires `ScaledFP8WeightTensor` to exist, which only happens for FP8-quantized weights. bf16 checkpoints never create these wrappers so the crash path is never reached.

## Testing

Verified end-to-end generation with LTX-2.3 22B FP8 checkpoint. No regressions expected for bf16 models as the changed code paths are only reached for `ScaledFP8WeightTensor` instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)