### PR TITLE
feat: add Res2s HQ sampler for LTX2 dev pipeline

### DIFF
--- a/models/ltx2/ltx2.py
+++ b/models/ltx2/ltx2.py
@@ -804,6 +804,8 @@ class LTX2:
         seed: int = 0,
         callback=None,
         VAE_tile_size=None,
+        hq_sampler: int = 0,
+        rescale_scale: float = 0.0,
         **kwargs,
     ):
         if self._interrupt:
@@ -1148,6 +1150,8 @@ class LTX2:
                 self_refiner_f_uncertainty=self_refiner_f_uncertainty,
                 self_refiner_certain_percentage=self_refiner_certain_percentage,
                 self_refiner_max_plans=self_refiner_max_plans,
+                hq_sampler=hq_sampler,
+                rescale_scale=rescale_scale,
             )
         else:
             pipeline_output = self.pipeline(

--- a/models/ltx2/ltx2.py
+++ b/models/ltx2/ltx2.py
@@ -1151,7 +1151,7 @@ class LTX2:
                 self_refiner_certain_percentage=self_refiner_certain_percentage,
                 self_refiner_max_plans=self_refiner_max_plans,
                 hq_sampler=hq_sampler,
-                rescale_scale=rescale_scale,
+                rescale_scale=float(alt_scale) if hq_sampler else rescale_scale,
             )
         else:
             pipeline_output = self.pipeline(

--- a/models/ltx2/ltx2_handler.py
+++ b/models/ltx2/ltx2_handler.py
@@ -225,6 +225,7 @@ class family_handler:
                         ("Skip Self Attention", 2),
                     ],
                     "perturbation_layers_max": 48,
+                    "hq_sampler": True,
                 }
             )
         extra_model_def["guidance_max_phases"] = 2

--- a/models/ltx2/ltx_core/components/diffusion_steps.py
+++ b/models/ltx2/ltx_core/components/diffusion_steps.py
@@ -42,7 +42,7 @@ class Res2sDiffusionStep(DiffusionStepProtocol):
             alpha_ratio = (1 - sigma_next) / (1 - sigma_down)
             sigma_up = (sigma_next**2 - sigma_down**2 * alpha_ratio**2).clamp(min=0) ** 0.5
         elif sigma_up is not None:
-            sigma_up.clamp_(max=sigma_next * 0.9999)
+            sigma_up = sigma_up.clamp(max=sigma_next * 0.9999)
             sigmax = sigma_max if sigma_max is not None else torch.ones_like(sigma_next)
             sigma_signal = sigmax - sigma_next
             sigma_residual = (sigma_next**2 - sigma_up**2).clamp(min=0) ** 0.5
@@ -55,7 +55,7 @@ class Res2sDiffusionStep(DiffusionStepProtocol):
 
         sigma_up = torch.nan_to_num(sigma_up if sigma_up is not None else torch.zeros_like(sigma_next), 0.0)
         nan_mask = torch.isnan(sigma_down)
-        sigma_down[nan_mask] = sigma_next[nan_mask].to(sigma_down.dtype)
+        sigma_down = torch.where(nan_mask, sigma_next.to(sigma_down.dtype), sigma_down)
         alpha_ratio = torch.nan_to_num(alpha_ratio, 1.0)
 
         return alpha_ratio, sigma_down, sigma_up

--- a/models/ltx2/ltx_core/components/diffusion_steps.py
+++ b/models/ltx2/ltx_core/components/diffusion_steps.py
@@ -20,3 +20,64 @@ class EulerDiffusionStep(DiffusionStepProtocol):
         velocity = to_velocity(sample, sigma, denoised_sample)
 
         return (sample.to(torch.float32) + velocity.to(torch.float32) * dt).to(sample.dtype)
+
+
+class Res2sDiffusionStep(DiffusionStepProtocol):
+    """Second-order diffusion step for res_2s sampling with SDE noise injection.
+
+    Used by the res_2s denoising loop.  Advances the sample from the current
+    sigma to the next by mixing a deterministic update with injected noise,
+    producing variance-preserving transitions.
+    """
+
+    @staticmethod
+    def get_sde_coeff(
+        sigma_next: torch.Tensor,
+        sigma_up: torch.Tensor | None = None,
+        sigma_down: torch.Tensor | None = None,
+        sigma_max: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Compute SDE coefficients (alpha_ratio, sigma_down, sigma_up)."""
+        if sigma_down is not None:
+            alpha_ratio = (1 - sigma_next) / (1 - sigma_down)
+            sigma_up = (sigma_next**2 - sigma_down**2 * alpha_ratio**2).clamp(min=0) ** 0.5
+        elif sigma_up is not None:
+            sigma_up.clamp_(max=sigma_next * 0.9999)
+            sigmax = sigma_max if sigma_max is not None else torch.ones_like(sigma_next)
+            sigma_signal = sigmax - sigma_next
+            sigma_residual = (sigma_next**2 - sigma_up**2).clamp(min=0) ** 0.5
+            alpha_ratio = sigma_signal + sigma_residual
+            sigma_down = sigma_residual / alpha_ratio
+        else:
+            alpha_ratio = torch.ones_like(sigma_next)
+            sigma_down = sigma_next
+            sigma_up = torch.zeros_like(sigma_next)
+
+        sigma_up = torch.nan_to_num(sigma_up if sigma_up is not None else torch.zeros_like(sigma_next), 0.0)
+        nan_mask = torch.isnan(sigma_down)
+        sigma_down[nan_mask] = sigma_next[nan_mask].to(sigma_down.dtype)
+        alpha_ratio = torch.nan_to_num(alpha_ratio, 1.0)
+
+        return alpha_ratio, sigma_down, sigma_up
+
+    def step(
+        self,
+        sample: torch.Tensor,
+        denoised_sample: torch.Tensor,
+        sigmas: torch.Tensor,
+        step_index: int,
+        noise: torch.Tensor = None,
+    ) -> torch.Tensor:
+        """Advance one step with SDE noise injection."""
+        sigma = sigmas[step_index]
+        sigma_next = sigmas[step_index + 1]
+        alpha_ratio, sigma_down, sigma_up = self.get_sde_coeff(sigma_next, sigma_up=sigma_next * 0.5)
+        output_dtype = denoised_sample.dtype
+        if torch.any(sigma_up == 0) or torch.any(sigma_next == 0):
+            return denoised_sample
+
+        eps_next = (sample - denoised_sample) / (sigma - sigma_next)
+        denoised_next = sample - sigma * eps_next
+
+        x_noised = alpha_ratio * (denoised_next + sigma_down * eps_next) + sigma_up * noise
+        return x_noised.to(output_dtype)

--- a/models/ltx2/ltx_core/components/guiders.py
+++ b/models/ltx2/ltx_core/components/guiders.py
@@ -1,4 +1,5 @@
-from dataclasses import dataclass
+import math
+from dataclasses import dataclass, field
 
 import torch
 
@@ -187,6 +188,62 @@ class LegacyStatefulAPGGuider(GuiderProtocol):
 
     def enabled(self) -> bool:
         return self.scale != 0.0
+
+
+@dataclass(frozen=True)
+class MultiModalGuiderParams:
+    """Parameters for the multi-modal guider (official HQ pipeline)."""
+
+    cfg_scale: float = 1.0
+    stg_scale: float = 0.0
+    stg_blocks: list[int] | None = field(default_factory=list)
+    rescale_scale: float = 0.0
+    modality_scale: float = 1.0
+    skip_step: int = 0
+
+
+@dataclass(frozen=True)
+class MultiModalGuider:
+    """Unified multi-modal guider combining CFG, STG, modality guidance, and rescaling.
+
+    Ported from the official LTX-2 reference implementation.
+    """
+
+    params: MultiModalGuiderParams
+    negative_context: torch.Tensor | None = None
+
+    def calculate(
+        self,
+        cond: torch.Tensor,
+        uncond_text: "torch.Tensor | float",
+        uncond_perturbed: "torch.Tensor | float",
+        uncond_modality: "torch.Tensor | float",
+    ) -> torch.Tensor:
+        pred = (
+            cond
+            + (self.params.cfg_scale - 1) * (cond - uncond_text)
+            + self.params.stg_scale * (cond - uncond_perturbed)
+            + (self.params.modality_scale - 1) * (cond - uncond_modality)
+        )
+        if self.params.rescale_scale != 0:
+            factor = cond.std() / pred.std()
+            factor = self.params.rescale_scale * factor + (1 - self.params.rescale_scale)
+            pred = pred * factor
+        return pred
+
+    def do_unconditional_generation(self) -> bool:
+        return not math.isclose(self.params.cfg_scale, 1.0)
+
+    def do_perturbed_generation(self) -> bool:
+        return not math.isclose(self.params.stg_scale, 0.0)
+
+    def do_isolated_modality_generation(self) -> bool:
+        return not math.isclose(self.params.modality_scale, 1.0)
+
+    def should_skip_step(self, step: int) -> bool:
+        if self.params.skip_step == 0:
+            return False
+        return step % (self.params.skip_step + 1) != 0
 
 
 def projection_coef(to_project: torch.Tensor, project_onto: torch.Tensor) -> torch.Tensor:

--- a/models/ltx2/ltx_core/components/guiders.py
+++ b/models/ltx2/ltx_core/components/guiders.py
@@ -228,6 +228,7 @@ class MultiModalGuider:
         if self.params.rescale_scale != 0:
             factor = cond.std() / pred.std()
             factor = self.params.rescale_scale * factor + (1 - self.params.rescale_scale)
+            print(f"[RESCALE DEBUG] cond.std={cond.std().item():.4f}, pred.std={pred.std().item():.4f}, raw_factor={cond.std().item()/pred.std().item():.4f}, final_factor={factor.item():.4f}, rescale_scale={self.params.rescale_scale}")
             pred = pred * factor
         return pred
 

--- a/models/ltx2/ltx_core/components/guiders.py
+++ b/models/ltx2/ltx_core/components/guiders.py
@@ -228,7 +228,6 @@ class MultiModalGuider:
         if self.params.rescale_scale != 0:
             factor = cond.std() / pred.std()
             factor = self.params.rescale_scale * factor + (1 - self.params.rescale_scale)
-            print(f"[RESCALE DEBUG] cond.std={cond.std().item():.4f}, pred.std={pred.std().item():.4f}, raw_factor={cond.std().item()/pred.std().item():.4f}, final_factor={factor.item():.4f}, rescale_scale={self.params.rescale_scale}")
             pred = pred * factor
         return pred
 

--- a/models/ltx2/ltx_pipelines/ti2vid_two_stages.py
+++ b/models/ltx2/ltx_pipelines/ti2vid_two_stages.py
@@ -31,6 +31,8 @@ from .utils.helpers import (
     generate_enhanced_prompt,
     get_device,
     guider_denoising_func,
+    multi_modal_guider_denoising_func,
+    res2s_audio_video_denoising_loop,
     image_conditionings_by_adding_guiding_latent,
     image_conditionings_by_replacing_latent,
     latent_conditionings_by_latent_sequence,
@@ -160,13 +162,19 @@ class TI2VidTwoStagesPipeline:
         self_refiner_f_uncertainty: float = 0.1,
         self_refiner_certain_percentage: float = 0.999,
         self_refiner_max_plans: int = 1,
+        hq_sampler: int = 0,
+        rescale_scale: float = 0.0,
     ) -> tuple[Iterator[torch.Tensor], torch.Tensor]:
         assert_resolution(height=height, width=width, is_two_stage=True)
 
         generator = torch.Generator(device=self.device).manual_seed(seed)
         mask_generator = torch.Generator(device=self.device).manual_seed(int(seed) + 1)
         noiser = GaussianNoiser(generator=generator)
-        stepper = EulerDiffusionStep()
+        if hq_sampler:
+            from ..ltx_core.components.diffusion_steps import Res2sDiffusionStep
+            stepper = Res2sDiffusionStep()
+        else:
+            stepper = EulerDiffusionStep()
         self_refiner_handler = None
         self_refiner_handler_audio = None
         self_refiner_handler_stage2 = None
@@ -205,13 +213,30 @@ class TI2VidTwoStagesPipeline:
                     channel_dim=-1,
                 )
         audio_cfg_guidance_scale = cfg_guidance_scale if audio_cfg_guidance_scale is None else audio_cfg_guidance_scale
-        guider_cls = CFGGuider
-        if apg_switch:
-            guider_cls = LtxAPGGuider
-        elif cfg_star_switch:
-            guider_cls = CFGStarRescalingGuider
-        video_cfg_guider = guider_cls(cfg_guidance_scale)
-        audio_cfg_guider = guider_cls(audio_cfg_guidance_scale)
+        if hq_sampler:
+            from ..ltx_core.components.guiders import MultiModalGuider, MultiModalGuiderParams
+            video_guider_params = MultiModalGuiderParams(
+                cfg_scale=cfg_guidance_scale,
+                stg_scale=0.0,
+                rescale_scale=rescale_scale,
+                modality_scale=alt_guidance_scale if alt_guidance_scale != 1.0 else 1.0,
+                stg_blocks=perturbation_layers if perturbation_layers else [],
+            )
+            audio_guider_params = MultiModalGuiderParams(
+                cfg_scale=audio_cfg_guidance_scale,
+                stg_scale=0.0,
+                rescale_scale=rescale_scale,
+                modality_scale=alt_guidance_scale if alt_guidance_scale != 1.0 else 1.0,
+                stg_blocks=perturbation_layers if perturbation_layers else [],
+            )
+        else:
+            guider_cls = CFGGuider
+            if apg_switch:
+                guider_cls = LtxAPGGuider
+            elif cfg_star_switch:
+                guider_cls = CFGStarRescalingGuider
+            video_cfg_guider = guider_cls(cfg_guidance_scale)
+            audio_cfg_guider = guider_cls(audio_cfg_guidance_scale)
         dtype = torch.bfloat16
 
         text_encoder = self._get_stage_model(1, "text_encoder")
@@ -272,6 +297,27 @@ class TI2VidTwoStagesPipeline:
             preview_tools: VideoLatentTools | None = None,
             mask_context=None,
         ) -> tuple[LatentState, LatentState]:
+            if hq_sampler:
+                video_guider = MultiModalGuider(params=video_guider_params, negative_context=v_context_n)
+                audio_guider = MultiModalGuider(params=audio_guider_params, negative_context=a_context_n)
+                return res2s_audio_video_denoising_loop(
+                    sigmas=sigmas,
+                    video_state=video_state,
+                    audio_state=audio_state,
+                    stepper=stepper,
+                    denoise_fn=multi_modal_guider_denoising_func(
+                        video_guider, audio_guider,
+                        v_context_p, a_context_p,
+                        transformer=transformer,
+                    ),
+                    noise_seed=seed,
+                    mask_context=mask_context,
+                    interrupt_check=interrupt_check,
+                    callback=callback,
+                    preview_tools=preview_tools,
+                    pass_no=1,
+                    transformer=transformer,
+                )
             return euler_denoising_loop(
                 sigmas=sigmas,
                 video_state=video_state,
@@ -421,17 +467,33 @@ class TI2VidTwoStagesPipeline:
             preview_tools: VideoLatentTools | None = None,
             mask_context=None,
         ) -> tuple[LatentState, LatentState]:
+            stage2_denoise_fn = simple_denoising_func(
+                video_context=v_context_p,
+                audio_context=a_context_p,
+                transformer=transformer,  # noqa: F821
+                alt_guidance_scale=1.0,
+            )
+            if hq_sampler:
+                return res2s_audio_video_denoising_loop(
+                    sigmas=sigmas,
+                    video_state=video_state,
+                    audio_state=audio_state,
+                    stepper=stepper,
+                    denoise_fn=stage2_denoise_fn,
+                    noise_seed=seed + 1,
+                    mask_context=mask_context,
+                    interrupt_check=interrupt_check,
+                    callback=callback,
+                    preview_tools=preview_tools,
+                    pass_no=2,
+                    transformer=transformer,
+                )
             return euler_denoising_loop(
                 sigmas=sigmas,
                 video_state=video_state,
                 audio_state=audio_state,
                 stepper=stepper,
-                denoise_fn=simple_denoising_func(
-                    video_context=v_context_p,
-                    audio_context=a_context_p,
-                    transformer=transformer,  # noqa: F821
-                    alt_guidance_scale=1.0,
-                ),
+                denoise_fn=stage2_denoise_fn,
                 mask_context=mask_context,
                 interrupt_check=interrupt_check,
                 callback=callback,

--- a/models/ltx2/ltx_pipelines/ti2vid_two_stages.py
+++ b/models/ltx2/ltx_pipelines/ti2vid_two_stages.py
@@ -309,6 +309,7 @@ class TI2VidTwoStagesPipeline:
                         video_guider, audio_guider,
                         v_context_p, a_context_p,
                         transformer=transformer,
+                        v_context_n=v_context_n, a_context_n=a_context_n,
                     ),
                     noise_seed=seed,
                     mask_context=mask_context,

--- a/models/ltx2/ltx_pipelines/ti2vid_two_stages.py
+++ b/models/ltx2/ltx_pipelines/ti2vid_two_stages.py
@@ -453,7 +453,8 @@ class TI2VidTwoStagesPipeline:
         bind_interrupt_check(transformer, interrupt_check)
         distilled_sigmas = torch.Tensor(STAGE_2_DISTILLED_SIGMA_VALUES).to(self.device)
         if loras_slists is not None:
-            stage_2_steps = len(distilled_sigmas) - 1
+            # +1 accounts for the final denoise step in res2s loop (step_index == n_full_steps)
+            stage_2_steps = len(distilled_sigmas) - 1 + 1
             update_loras_slists(
                 transformer,
                 loras_slists,

--- a/models/ltx2/ltx_pipelines/ti2vid_two_stages.py
+++ b/models/ltx2/ltx_pipelines/ti2vid_two_stages.py
@@ -282,10 +282,13 @@ class TI2VidTwoStagesPipeline:
         video_encoder = self._get_stage_model(1, "video_encoder")
         transformer = self._get_stage_model(1, "transformer")
         bind_interrupt_check(transformer, interrupt_check)
-        # Pass latent shape to scheduler for resolution-dependent sigma shifting
-        from ..ltx_core.types import VideoLatentShape
-        empty_latent = torch.empty(VideoLatentShape.from_pixel_shape(stage_1_output_shape).to_torch_shape())
-        sigmas = LTX2Scheduler().execute(steps=num_inference_steps, latent=empty_latent).to(dtype=torch.float32, device=self.device)
+        if hq_sampler:
+            # HQ pipeline: resolution-dependent sigma shifting
+            from ..ltx_core.types import VideoLatentShape
+            empty_latent = torch.empty(VideoLatentShape.from_pixel_shape(stage_1_output_shape).to_torch_shape())
+            sigmas = LTX2Scheduler().execute(steps=num_inference_steps, latent=empty_latent).to(dtype=torch.float32, device=self.device)
+        else:
+            sigmas = LTX2Scheduler().execute(steps=num_inference_steps).to(dtype=torch.float32, device=self.device)
         if loras_slists is not None:
             stage_1_steps = len(sigmas) - 1
             update_loras_slists(

--- a/models/ltx2/ltx_pipelines/ti2vid_two_stages.py
+++ b/models/ltx2/ltx_pipelines/ti2vid_two_stages.py
@@ -272,10 +272,20 @@ class TI2VidTwoStagesPipeline:
         v_context_n, a_context_n = context_n
 
         # Stage 1: Initial low resolution video generation.
+        stage_1_output_shape = VideoPixelShape(
+            batch=1,
+            frames=num_frames,
+            width=width // 2,
+            height=height // 2,
+            fps=frame_rate,
+        )
         video_encoder = self._get_stage_model(1, "video_encoder")
         transformer = self._get_stage_model(1, "transformer")
         bind_interrupt_check(transformer, interrupt_check)
-        sigmas = LTX2Scheduler().execute(steps=num_inference_steps).to(dtype=torch.float32, device=self.device)
+        # Pass latent shape to scheduler for resolution-dependent sigma shifting
+        from ..ltx_core.types import VideoLatentShape
+        empty_latent = torch.empty(VideoLatentShape.from_pixel_shape(stage_1_output_shape).to_torch_shape())
+        sigmas = LTX2Scheduler().execute(steps=num_inference_steps, latent=empty_latent).to(dtype=torch.float32, device=self.device)
         if loras_slists is not None:
             stage_1_steps = len(sigmas) - 1
             update_loras_slists(
@@ -311,7 +321,6 @@ class TI2VidTwoStagesPipeline:
                         transformer=transformer,
                         v_context_n=v_context_n, a_context_n=a_context_n,
                     ),
-                    noise_seed=seed,
                     mask_context=mask_context,
                     interrupt_check=interrupt_check,
                     callback=callback,
@@ -350,13 +359,6 @@ class TI2VidTwoStagesPipeline:
                 self_refiner_generator=generator,
             )
 
-        stage_1_output_shape = VideoPixelShape(
-            batch=1,
-            frames=num_frames,
-            width=width // 2,
-            height=height // 2,
-            fps=frame_rate,
-        )
         stage_1_conditionings = image_conditionings_by_replacing_latent(
             images=images,
             height=stage_1_output_shape.height,
@@ -481,7 +483,6 @@ class TI2VidTwoStagesPipeline:
                     audio_state=audio_state,
                     stepper=stepper,
                     denoise_fn=stage2_denoise_fn,
-                    noise_seed=seed + 1,
                     mask_context=mask_context,
                     interrupt_check=interrupt_check,
                     callback=callback,

--- a/models/ltx2/ltx_pipelines/ti2vid_two_stages.py
+++ b/models/ltx2/ltx_pipelines/ti2vid_two_stages.py
@@ -215,19 +215,22 @@ class TI2VidTwoStagesPipeline:
         audio_cfg_guidance_scale = cfg_guidance_scale if audio_cfg_guidance_scale is None else audio_cfg_guidance_scale
         if hq_sampler:
             from ..ltx_core.components.guiders import MultiModalGuider, MultiModalGuiderParams
+            # STG: off by default (official HQ), user can enable via Perturbation UI
+            stg_scale = 1.0 if perturbation_switch and perturbation_layers else 0.0
+            stg_blocks = perturbation_layers if perturbation_layers else []
             video_guider_params = MultiModalGuiderParams(
                 cfg_scale=cfg_guidance_scale,
-                stg_scale=0.0,
+                stg_scale=stg_scale,
                 rescale_scale=rescale_scale,
                 modality_scale=alt_guidance_scale if alt_guidance_scale != 1.0 else 1.0,
-                stg_blocks=perturbation_layers if perturbation_layers else [],
+                stg_blocks=stg_blocks,
             )
             audio_guider_params = MultiModalGuiderParams(
                 cfg_scale=audio_cfg_guidance_scale,
-                stg_scale=0.0,
+                stg_scale=stg_scale,
                 rescale_scale=1.0,  # Official HQ uses 1.0 for audio (full rescaling)
                 modality_scale=alt_guidance_scale if alt_guidance_scale != 1.0 else 1.0,
-                stg_blocks=perturbation_layers if perturbation_layers else [],
+                stg_blocks=stg_blocks,
             )
         else:
             guider_cls = CFGGuider

--- a/models/ltx2/ltx_pipelines/ti2vid_two_stages.py
+++ b/models/ltx2/ltx_pipelines/ti2vid_two_stages.py
@@ -225,7 +225,7 @@ class TI2VidTwoStagesPipeline:
             audio_guider_params = MultiModalGuiderParams(
                 cfg_scale=audio_cfg_guidance_scale,
                 stg_scale=0.0,
-                rescale_scale=rescale_scale,
+                rescale_scale=1.0,  # Official HQ uses 1.0 for audio (full rescaling)
                 modality_scale=alt_guidance_scale if alt_guidance_scale != 1.0 else 1.0,
                 stg_blocks=perturbation_layers if perturbation_layers else [],
             )

--- a/models/ltx2/ltx_pipelines/utils/helpers.py
+++ b/models/ltx2/ltx_pipelines/utils/helpers.py
@@ -1568,8 +1568,10 @@ def res2s_audio_video_denoising_loop(
                 eps_1_audio = denoised_audio_1.double() - x_anchor_audio
 
         # Stage 2: evaluate at substep point
-        mid_video_state = replace(video_state, latent=x_mid_video.to(model_dtype))
-        mid_audio_state = replace(audio_state, latent=x_mid_audio.to(model_dtype))
+        # Use fresh runtime_cache to prevent stale base_timestep from main step (B8)
+        from ...ltx_core.types import LatentStateRuntimeCache
+        mid_video_state = replace(video_state, latent=x_mid_video.to(model_dtype), runtime_cache=LatentStateRuntimeCache())
+        mid_audio_state = replace(audio_state, latent=x_mid_audio.to(model_dtype), runtime_cache=LatentStateRuntimeCache())
 
         denoised_video_2, denoised_audio_2 = denoise_fn(
             video_state=mid_video_state, audio_state=mid_audio_state,

--- a/models/ltx2/ltx_pipelines/utils/helpers.py
+++ b/models/ltx2/ltx_pipelines/utils/helpers.py
@@ -1304,6 +1304,8 @@ def multi_modal_guider_denoising_func(
     v_context: torch.Tensor,
     a_context: torch.Tensor,
     transformer,
+    v_context_n: torch.Tensor | None = None,
+    a_context_n: torch.Tensor | None = None,
 ):
     """Denoising function using the official MultiModalGuider (HQ pipeline).
 
@@ -1319,21 +1321,46 @@ def multi_modal_guider_denoising_func(
 
     last_denoised_video = None
     last_denoised_audio = None
+    prepared_v_context = None
+    prepared_a_context = None
+    prepared_v_context_neg = None
+    prepared_a_context_neg = None
+
+    def _prewarm(video_state: LatentState, audio_state: LatentState, sigmas: torch.Tensor) -> None:
+        nonlocal prepared_v_context, prepared_a_context, prepared_v_context_neg, prepared_a_context_neg
+        if prepared_v_context is None:
+            prepared_v_context = _prepare_conditioning_context(transformer, video_state, v_context, sigmas, is_audio=False)
+        if prepared_a_context is None:
+            prepared_a_context = _prepare_conditioning_context(transformer, audio_state, a_context, sigmas, is_audio=True)
+        if v_context_n is not None and prepared_v_context_neg is None:
+            prepared_v_context_neg = _prepare_conditioning_context(transformer, video_state, v_context_n, sigmas, is_audio=False)
+        if a_context_n is not None and prepared_a_context_neg is None:
+            prepared_a_context_neg = _prepare_conditioning_context(transformer, audio_state, a_context_n, sigmas, is_audio=True)
+
+    def _cleanup() -> None:
+        nonlocal prepared_v_context, prepared_a_context, prepared_v_context_neg, prepared_a_context_neg
+        prepared_v_context = prepared_a_context = None
+        prepared_v_context_neg = prepared_a_context_neg = None
+        _clear_phase_timestep_embedders(transformer)
 
     def guider_denoising_step(
         video_state: LatentState, audio_state: LatentState, sigmas: torch.Tensor, step_index: int
     ) -> tuple[torch.Tensor, torch.Tensor]:
         nonlocal last_denoised_video, last_denoised_audio
 
+        _prewarm(video_state, audio_state, sigmas)
+
         if video_guider.should_skip_step(step_index) and audio_guider.should_skip_step(step_index):
             return last_denoised_video, last_denoised_audio
 
         sigma = sigmas[step_index]
         pos_video = modality_from_latent_state(
-            video_state, v_context, sigma, enabled=not video_guider.should_skip_step(step_index)
+            video_state, prepared_v_context, sigma, enabled=not video_guider.should_skip_step(step_index),
+            step_index=step_index, sigma_schedule=sigmas,
         )
         pos_audio = modality_from_latent_state(
-            audio_state, a_context, sigma, enabled=not audio_guider.should_skip_step(step_index)
+            audio_state, prepared_a_context, sigma, enabled=not audio_guider.should_skip_step(step_index),
+            step_index=step_index, sigma_schedule=sigmas,
         )
 
         denoised_video, denoised_audio = transformer(
@@ -1342,10 +1369,10 @@ def multi_modal_guider_denoising_func(
 
         neg_denoised_video, neg_denoised_audio = 0.0, 0.0
         if video_guider.do_unconditional_generation() or audio_guider.do_unconditional_generation():
-            neg_video_context = video_guider.negative_context if video_guider.negative_context is not None else v_context
-            neg_audio_context = audio_guider.negative_context if audio_guider.negative_context is not None else a_context
-            neg_video = modality_from_latent_state(video_state, neg_video_context, sigma)
-            neg_audio = modality_from_latent_state(audio_state, neg_audio_context, sigma)
+            neg_v_ctx = prepared_v_context_neg if prepared_v_context_neg is not None else prepared_v_context
+            neg_a_ctx = prepared_a_context_neg if prepared_a_context_neg is not None else prepared_a_context
+            neg_video = modality_from_latent_state(video_state, neg_v_ctx, sigma, step_index=step_index, sigma_schedule=sigmas)
+            neg_audio = modality_from_latent_state(audio_state, neg_a_ctx, sigma, step_index=step_index, sigma_schedule=sigmas)
             neg_denoised_video, neg_denoised_audio = transformer(
                 video=neg_video, audio=neg_audio, perturbations=None
             )
@@ -1397,6 +1424,8 @@ def multi_modal_guider_denoising_func(
         last_denoised_audio = denoised_audio
         return denoised_video, denoised_audio
 
+    guider_denoising_step._prewarm = _prewarm
+    guider_denoising_step._cleanup = _cleanup
     return guider_denoising_step
 
 
@@ -1493,6 +1522,7 @@ def res2s_audio_video_denoising_loop(
         if transformer is not None:
             offload.set_step_no_for_lora(transformer, step_idx)
 
+        _device = sigmas.device
         sigma = sigmas[step_idx].double()
         sigma_next = sigmas[step_idx + 1].double()
 
@@ -1519,13 +1549,14 @@ def res2s_audio_video_denoising_loop(
         x_mid_audio = x_anchor_audio + h * a21 * eps_1_audio
 
         # SDE noise injection at substep
+        _sde_substep_sigmas = torch.stack([sigma, sub_sigma]).to(dtype=torch.float32, device=_device)
         x_mid_video = substep_noise_injecting_fn(
             state=video_state, sample=x_anchor_video, denoised_sample=x_mid_video,
-            sigmas=torch.stack([sigma, sub_sigma]), step_idx=0,
+            sigmas=_sde_substep_sigmas, step_idx=0,
         )
         x_mid_audio = substep_noise_injecting_fn(
             state=audio_state, sample=x_anchor_audio, denoised_sample=x_mid_audio,
-            sigmas=torch.stack([sigma, sub_sigma]), step_idx=0,
+            sigmas=_sde_substep_sigmas, step_idx=0,
         )
 
         # Bong iteration: stabilize anchor point
@@ -1542,7 +1573,7 @@ def res2s_audio_video_denoising_loop(
 
         denoised_video_2, denoised_audio_2 = denoise_fn(
             video_state=mid_video_state, audio_state=mid_audio_state,
-            sigmas=torch.stack([sub_sigma]).to(sigmas.device), step_index=0,
+            sigmas=torch.stack([sub_sigma, torch.zeros_like(sub_sigma)]).to(dtype=torch.float32, device=_device), step_index=0,
         )
         if denoised_video_2 is None or denoised_audio_2 is None:
             return None, None

--- a/models/ltx2/ltx_pipelines/utils/helpers.py
+++ b/models/ltx2/ltx_pipelines/utils/helpers.py
@@ -1298,6 +1298,284 @@ def guider_denoising_func(
     return guider_denoising_step
 
 
+def multi_modal_guider_denoising_func(
+    video_guider,
+    audio_guider,
+    v_context: torch.Tensor,
+    a_context: torch.Tensor,
+    transformer,
+):
+    """Denoising function using the official MultiModalGuider (HQ pipeline).
+
+    Ported from the official LTX-2 reference.  Handles CFG, STG, modality
+    guidance, and rescaling in a single unified pass via MultiModalGuider.calculate().
+    """
+    from ...ltx_core.guidance.perturbations import (
+        BatchedPerturbationConfig,
+        Perturbation,
+        PerturbationConfig,
+        PerturbationType,
+    )
+
+    last_denoised_video = None
+    last_denoised_audio = None
+
+    def guider_denoising_step(
+        video_state: LatentState, audio_state: LatentState, sigmas: torch.Tensor, step_index: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        nonlocal last_denoised_video, last_denoised_audio
+
+        if video_guider.should_skip_step(step_index) and audio_guider.should_skip_step(step_index):
+            return last_denoised_video, last_denoised_audio
+
+        sigma = sigmas[step_index]
+        pos_video = modality_from_latent_state(
+            video_state, v_context, sigma, enabled=not video_guider.should_skip_step(step_index)
+        )
+        pos_audio = modality_from_latent_state(
+            audio_state, a_context, sigma, enabled=not audio_guider.should_skip_step(step_index)
+        )
+
+        denoised_video, denoised_audio = transformer(
+            video=pos_video, audio=pos_audio, perturbations=None
+        )
+
+        neg_denoised_video, neg_denoised_audio = 0.0, 0.0
+        if video_guider.do_unconditional_generation() or audio_guider.do_unconditional_generation():
+            neg_video_context = video_guider.negative_context if video_guider.negative_context is not None else v_context
+            neg_audio_context = audio_guider.negative_context if audio_guider.negative_context is not None else a_context
+            neg_video = modality_from_latent_state(video_state, neg_video_context, sigma)
+            neg_audio = modality_from_latent_state(audio_state, neg_audio_context, sigma)
+            neg_denoised_video, neg_denoised_audio = transformer(
+                video=neg_video, audio=neg_audio, perturbations=None
+            )
+
+        ptb_denoised_video, ptb_denoised_audio = 0.0, 0.0
+        if video_guider.do_perturbed_generation() or audio_guider.do_perturbed_generation():
+            perturbations = []
+            if video_guider.do_perturbed_generation():
+                perturbations.append(
+                    Perturbation(type=PerturbationType.SKIP_VIDEO_SELF_ATTN, blocks=video_guider.params.stg_blocks)
+                )
+            if audio_guider.do_perturbed_generation():
+                perturbations.append(
+                    Perturbation(type=PerturbationType.SKIP_AUDIO_SELF_ATTN, blocks=audio_guider.params.stg_blocks)
+                )
+            perturbation_config = PerturbationConfig(perturbations=perturbations)
+            ptb_denoised_video, ptb_denoised_audio = transformer(
+                video=pos_video, audio=pos_audio,
+                perturbations=BatchedPerturbationConfig(perturbations=[perturbation_config]),
+            )
+
+        mod_denoised_video, mod_denoised_audio = 0.0, 0.0
+        if video_guider.do_isolated_modality_generation() or audio_guider.do_isolated_modality_generation():
+            perturbations = [
+                Perturbation(type=PerturbationType.SKIP_A2V_CROSS_ATTN, blocks=None),
+                Perturbation(type=PerturbationType.SKIP_V2A_CROSS_ATTN, blocks=None),
+            ]
+            perturbation_config = PerturbationConfig(perturbations=perturbations)
+            mod_denoised_video, mod_denoised_audio = transformer(
+                video=pos_video, audio=pos_audio,
+                perturbations=BatchedPerturbationConfig(perturbations=[perturbation_config]),
+            )
+
+        if not video_guider.should_skip_step(step_index):
+            denoised_video = video_guider.calculate(
+                denoised_video, neg_denoised_video, ptb_denoised_video, mod_denoised_video
+            )
+        else:
+            denoised_video = last_denoised_video
+
+        if not audio_guider.should_skip_step(step_index):
+            denoised_audio = audio_guider.calculate(
+                denoised_audio, neg_denoised_audio, ptb_denoised_audio, mod_denoised_audio
+            )
+        else:
+            denoised_audio = last_denoised_audio
+
+        last_denoised_video = denoised_video
+        last_denoised_audio = denoised_audio
+        return denoised_video, denoised_audio
+
+    return guider_denoising_step
+
+
+def _channelwise_normalize(x: torch.Tensor) -> torch.Tensor:
+    return x.sub_(x.mean(dim=(-2, -1), keepdim=True)).div_(x.std(dim=(-2, -1), keepdim=True))
+
+
+def _get_new_noise(x: torch.Tensor, generator: torch.Generator) -> torch.Tensor:
+    noise = torch.randn(x.shape, generator=generator, dtype=torch.float64, device=generator.device)
+    noise = (noise - noise.mean()) / noise.std()
+    return _channelwise_normalize(noise)
+
+
+def _inject_sde_noise(
+    state: LatentState,
+    sample: torch.Tensor,
+    denoised_sample: torch.Tensor,
+    step_noise_generator: torch.Generator,
+    new_noise_fn,
+    stepper,
+    sigmas: torch.Tensor,
+    step_idx: int,
+    legacy_mode: bool = False,
+) -> torch.Tensor:
+    from ...ltx_core.components.diffusion_steps import Res2sDiffusionStep
+    sigmas_copy = sigmas.clone()
+    new_noise = new_noise_fn(state.latent, step_noise_generator)
+    if not legacy_mode:
+        timesteps = timesteps_from_mask(state.denoise_mask.double(), sigmas_copy[step_idx].double())
+        next_timesteps = timesteps_from_mask(state.denoise_mask.double(), sigmas_copy[step_idx + 1].double())
+        sigmas = torch.stack([timesteps, next_timesteps])
+        step_idx = 0
+    x_next = stepper.step(
+        sample=sample, denoised_sample=denoised_sample,
+        sigmas=sigmas, step_index=step_idx, noise=new_noise,
+    )
+    if legacy_mode:
+        x_next = post_process_latent(x_next, state.denoise_mask, state.clean_latent)
+    return x_next
+
+
+def res2s_audio_video_denoising_loop(
+    sigmas: torch.Tensor,
+    video_state: LatentState,
+    audio_state: LatentState,
+    stepper,
+    denoise_fn,
+    *,
+    noise_seed: int = -1,
+    noise_seed_substep: int | None = None,
+    bongmath: bool = True,
+    bongmath_max_iter: int = 100,
+    model_dtype: torch.dtype = torch.bfloat16,
+    legacy_mode: bool = True,
+    mask_context=None,
+    interrupt_check=None,
+    callback=None,
+    preview_tools=None,
+    pass_no: int = 0,
+    transformer=None,
+) -> tuple[LatentState | None, LatentState | None]:
+    """Joint audio-video denoising loop using the res_2s second-order sampler.
+
+    Ported from the official LTX-2 reference.  Two-stage Runge-Kutta with SDE
+    noise injection and optional anchor-point refinement (bong iteration).
+    """
+    from functools import partial
+    from ...ltx_core.components.diffusion_steps import Res2sDiffusionStep
+    from .res2s import get_res2s_coefficients
+
+    if noise_seed_substep is None:
+        noise_seed_substep = noise_seed + 10000
+    step_noise_generator = torch.Generator(device=video_state.latent.device).manual_seed(noise_seed)
+    substep_noise_generator = torch.Generator(device=video_state.latent.device).manual_seed(noise_seed_substep)
+
+    sde_noise_injecting_fn = partial(
+        _inject_sde_noise, stepper=stepper, new_noise_fn=_get_new_noise, legacy_mode=legacy_mode
+    )
+    step_noise_injecting_fn = partial(sde_noise_injecting_fn, step_noise_generator=step_noise_generator)
+    substep_noise_injecting_fn = partial(sde_noise_injecting_fn, step_noise_generator=substep_noise_generator)
+
+    n_full_steps = len(sigmas) - 1
+    if sigmas[-1] == 0:
+        sigmas = torch.cat([sigmas[:-1], torch.tensor([0.0011, 0.0], device=sigmas.device)], dim=0)
+    hs = -torch.log(sigmas[1:].double().cpu() / (sigmas[:-1].double().cpu()))
+
+    phi_cache = {}
+    c2 = 0.5
+
+    for step_idx in tqdm(range(n_full_steps)):
+        if interrupt_check is not None and interrupt_check():
+            return None, None
+
+        if transformer is not None:
+            offload.set_step_no_for_lora(transformer, step_idx)
+
+        sigma = sigmas[step_idx].double()
+        sigma_next = sigmas[step_idx + 1].double()
+
+        x_anchor_video = video_state.latent.clone().double()
+        x_anchor_audio = audio_state.latent.clone().double()
+
+        # Stage 1: evaluate at current point
+        denoised_video_1, denoised_audio_1 = denoise_fn(video_state, audio_state, sigmas, step_idx)
+        if denoised_video_1 is None or denoised_audio_1 is None:
+            return None, None
+        denoised_video_1 = post_process_latent(denoised_video_1, video_state.denoise_mask, video_state.clean_latent)
+        denoised_audio_1 = post_process_latent(denoised_audio_1, audio_state.denoise_mask, audio_state.clean_latent)
+
+        h = hs[step_idx].item()
+        a21, b1, b2 = get_res2s_coefficients(h, phi_cache, c2)
+
+        sub_sigma = torch.sqrt(sigma * sigma_next)
+
+        # Compute substep x using RK coefficient a21
+        eps_1_video = denoised_video_1.double() - x_anchor_video
+        eps_1_audio = denoised_audio_1.double() - x_anchor_audio
+
+        x_mid_video = x_anchor_video + h * a21 * eps_1_video
+        x_mid_audio = x_anchor_audio + h * a21 * eps_1_audio
+
+        # SDE noise injection at substep
+        x_mid_video = substep_noise_injecting_fn(
+            state=video_state, sample=x_anchor_video, denoised_sample=x_mid_video,
+            sigmas=torch.stack([sigma, sub_sigma]), step_idx=0,
+        )
+        x_mid_audio = substep_noise_injecting_fn(
+            state=audio_state, sample=x_anchor_audio, denoised_sample=x_mid_audio,
+            sigmas=torch.stack([sigma, sub_sigma]), step_idx=0,
+        )
+
+        # Bong iteration: stabilize anchor point
+        if bongmath and h < 0.5 and sigma > 0.03:
+            for _ in range(bongmath_max_iter):
+                x_anchor_video = x_mid_video - h * a21 * eps_1_video
+                eps_1_video = denoised_video_1.double() - x_anchor_video
+                x_anchor_audio = x_mid_audio - h * a21 * eps_1_audio
+                eps_1_audio = denoised_audio_1.double() - x_anchor_audio
+
+        # Stage 2: evaluate at substep point
+        mid_video_state = replace(video_state, latent=x_mid_video.to(model_dtype))
+        mid_audio_state = replace(audio_state, latent=x_mid_audio.to(model_dtype))
+
+        denoised_video_2, denoised_audio_2 = denoise_fn(
+            video_state=mid_video_state, audio_state=mid_audio_state,
+            sigmas=torch.stack([sub_sigma]).to(sigmas.device), step_index=0,
+        )
+        if denoised_video_2 is None or denoised_audio_2 is None:
+            return None, None
+        denoised_video_2 = post_process_latent(denoised_video_2, video_state.denoise_mask, video_state.clean_latent)
+        denoised_audio_2 = post_process_latent(denoised_audio_2, audio_state.denoise_mask, audio_state.clean_latent)
+
+        # Final combination using RK coefficients
+        eps_2_video = denoised_video_2.double() - x_anchor_video
+        eps_2_audio = denoised_audio_2.double() - x_anchor_audio
+
+        x_next_video = x_anchor_video + h * (b1 * eps_1_video + b2 * eps_2_video)
+        x_next_audio = x_anchor_audio + h * (b1 * eps_1_audio + b2 * eps_2_audio)
+
+        # SDE noise injection at step level
+        x_next_video = step_noise_injecting_fn(
+            state=video_state, sample=x_anchor_video, denoised_sample=x_next_video,
+            sigmas=sigmas, step_idx=step_idx,
+        )
+        x_next_audio = step_noise_injecting_fn(
+            state=audio_state, sample=x_anchor_audio, denoised_sample=x_next_audio,
+            sigmas=sigmas, step_idx=step_idx,
+        )
+
+        video_state = replace(video_state, latent=x_next_video.to(model_dtype))
+        audio_state = replace(audio_state, latent=x_next_audio.to(model_dtype))
+
+        if mask_context is not None:
+            _apply_mask_injection(video_state, sigmas, step_idx, mask_context)
+        _invoke_callback(callback, step_idx, pass_no, video_state, preview_tools)
+
+    return video_state, audio_state
+
+
 def denoise_audio_video(  # noqa: PLR0913
     output_shape: VideoPixelShape,
     conditionings: list[ConditioningItem],

--- a/models/ltx2/ltx_pipelines/utils/helpers.py
+++ b/models/ltx2/ltx_pipelines/utils/helpers.py
@@ -1573,7 +1573,7 @@ def res2s_audio_video_denoising_loop(
 
         denoised_video_2, denoised_audio_2 = denoise_fn(
             video_state=mid_video_state, audio_state=mid_audio_state,
-            sigmas=torch.stack([sub_sigma, torch.zeros_like(sub_sigma)]).to(dtype=torch.float32, device=_device), step_index=0,
+            sigmas=torch.stack([sub_sigma]).to(dtype=torch.float32, device=_device), step_index=0,
         )
         if denoised_video_2 is None or denoised_audio_2 is None:
             return None, None
@@ -1603,6 +1603,15 @@ def res2s_audio_video_denoising_loop(
         if mask_context is not None:
             _apply_mask_injection(video_state, sigmas, step_idx, mask_context)
         _invoke_callback(callback, step_idx, pass_no, video_state, preview_tools)
+
+    # Final step: fully denoise when last sigma is 0
+    if sigmas[-1] == 0:
+        denoised_video_final, denoised_audio_final = denoise_fn(video_state, audio_state, sigmas, n_full_steps)
+        if denoised_video_final is not None and denoised_audio_final is not None:
+            denoised_video_final = post_process_latent(denoised_video_final, video_state.denoise_mask, video_state.clean_latent)
+            denoised_audio_final = post_process_latent(denoised_audio_final, audio_state.denoise_mask, audio_state.clean_latent)
+            video_state = replace(video_state, latent=denoised_video_final.to(model_dtype))
+            audio_state = replace(audio_state, latent=denoised_audio_final.to(model_dtype))
 
     return video_state, audio_state
 

--- a/models/ltx2/ltx_pipelines/utils/res2s.py
+++ b/models/ltx2/ltx_pipelines/utils/res2s.py
@@ -1,0 +1,48 @@
+"""Res2s Runge-Kutta coefficient computation for the second-order sampler.
+
+Ported from the official LTX-2 reference implementation.
+"""
+
+import math
+
+
+def phi(j: int, neg_h: float) -> float:
+    """Compute phi_j(z) where z = -h (negative step size in log-space).
+
+    These functions appear when solving dx/dt = A*x + g(x,t).
+    phi_1(z) = (e^z - 1) / z
+    phi_2(z) = (e^z - 1 - z) / z^2
+    """
+    if abs(neg_h) < 1e-10:
+        return 1.0 / math.factorial(j)
+    remainder = sum(neg_h**k / math.factorial(k) for k in range(j))
+    return (math.exp(neg_h) - remainder) / (neg_h**j)
+
+
+def get_res2s_coefficients(h: float, phi_cache: dict, c2: float = 0.5) -> tuple[float, float, float]:
+    """Compute res_2s Runge-Kutta coefficients for a given step size.
+
+    Returns (a21, b1, b2) where:
+    - a21: coefficient for computing intermediate x
+    - b1, b2: coefficients for final combination
+    """
+    def get_phi(j: int, neg_h: float) -> float:
+        cache_key = (j, neg_h)
+        if cache_key in phi_cache:
+            return phi_cache[cache_key]
+        result = phi(j, neg_h)
+        phi_cache[cache_key] = result
+        return result
+
+    neg_h_c2 = -h * c2
+    phi_1_c2 = get_phi(1, neg_h_c2)
+    a21 = c2 * phi_1_c2
+
+    neg_h_full = -h
+    phi_2_full = get_phi(2, neg_h_full)
+    b2 = phi_2_full / c2
+
+    phi_1_full = get_phi(1, neg_h_full)
+    b1 = phi_1_full - b2
+
+    return a21, b1, b2

--- a/wgp.py
+++ b/wgp.py
@@ -10556,11 +10556,13 @@ def generate_video_tab(update_form = False, state_dict = None, ui_defaults = Non
                 any_hq_sampler = model_def.get("hq_sampler", False)
                 with gr.Tab("Quality", visible = (vace and image_outputs or any_perturbation or any_cfg_zero or any_cfg_star or any_apg or any_motion_amplitude or any_pnp or any_hq_sampler) and not audio_only ) as quality_tab:
                         with gr.Column(visible=any_hq_sampler) as hq_sampler_col:
-                            gr.Markdown("<B>Sampler (Res2s HQ uses a second-order sampler for better quality at fewer steps)</B>")
-                            with gr.Row():
-                                hq_sampler = gr.Dropdown(choices=[("Euler (Standard)", 0), ("Res2s (HQ)", 1)], value=ui_get("hq_sampler", 0), label="Sampler", scale=1)
-                                rescale_scale = gr.Slider(0, 1, value=ui_get("rescale_scale", 0.0), step=0.05, label="Rescale Scale (0=off, 0.45=recommended for HQ)", scale=2, show_reset_button=False)
-                            gr.Markdown("<I>Res2s HQ is designed for 15 steps with a distilled LoRA at 0.25 strength, CFG 3, Rescale 0.45</I>")
+                            gr.Markdown("<B>Sampler</B>")
+                            hq_sampler = gr.Dropdown(choices=[("Euler (Standard)", 0), ("Res2s (HQ)", 1)], value=ui_get("hq_sampler", 0), label="Sampler", scale=1)
+                            with gr.Column(visible=(update_form and ui_get("hq_sampler", 0) == 1)) as hq_sampler_options:
+                                rescale_scale = gr.Slider(0, 1, value=ui_get("rescale_scale", 0.0), step=0.05, label="Rescale Scale (0=off, 0.45=recommended for HQ)", show_reset_button=False)
+                                gr.Markdown("<I>Res2s HQ is designed for 15 steps with a distilled LoRA at 0.25 strength, CFG 3, Rescale 0.45</I>")
+                            if not update_form:
+                                hq_sampler.change(fn=lambda v: gr.update(visible=v == 1), inputs=[hq_sampler], outputs=[hq_sampler_options])
                         with gr.Column(visible = any_perturbation ) as perturbation_row:
                             gr.Markdown("<B>Perturbation (improves video quality, requires guidance > 1)</B>")
                             perturbation_choices = model_def.get("perturbation_choices", [("OFF", 0), ("Skip Layer Guidance", 1)])

--- a/wgp.py
+++ b/wgp.py
@@ -4549,9 +4549,14 @@ def select_video(state, current_gallery_tab, input_file_list, file_selected, aud
                 # values += [f"Norm P{video_self_refiner_setting}, Plan='{video_self_refiner_plan}'"]
                 labels += ["Self Refiner"]      
             video_apg_switch = configs.get("apg_switch", None)
-            if video_apg_switch is not None and video_apg_switch != 0: 
+            if video_apg_switch is not None and video_apg_switch != 0:
                 values += ["on"]
-                labels += ["APG"]      
+                labels += ["APG"]
+            video_hq_sampler = configs.get("hq_sampler", 0)
+            if video_hq_sampler:
+                video_rescale = configs.get("rescale_scale", 0.0)
+                values += [f"Res2s (HQ), Rescale={video_rescale}"]
+                labels += ["Sampler"]
             video_motion_amplitude = configs.get("motion_amplitude", 1.)
             if  video_motion_amplitude != 1: 
                 values += [video_motion_amplitude]

--- a/wgp.py
+++ b/wgp.py
@@ -10560,6 +10560,7 @@ def generate_video_tab(update_form = False, state_dict = None, ui_defaults = Non
                             with gr.Row():
                                 hq_sampler = gr.Dropdown(choices=[("Euler (Standard)", 0), ("Res2s (HQ)", 1)], value=ui_get("hq_sampler", 0), label="Sampler", scale=1)
                                 rescale_scale = gr.Slider(0, 1, value=ui_get("rescale_scale", 0.0), step=0.05, label="Rescale Scale (0=off, 0.45=recommended for HQ)", scale=2, show_reset_button=False)
+                            gr.Markdown("<I>Res2s HQ is designed for 15 steps with a distilled LoRA at 0.25 strength, CFG 3, Rescale 0.45</I>")
                         with gr.Column(visible = any_perturbation ) as perturbation_row:
                             gr.Markdown("<B>Perturbation (improves video quality, requires guidance > 1)</B>")
                             perturbation_choices = model_def.get("perturbation_choices", [("OFF", 0), ("Skip Layer Guidance", 1)])

--- a/wgp.py
+++ b/wgp.py
@@ -4554,8 +4554,7 @@ def select_video(state, current_gallery_tab, input_file_list, file_selected, aud
                 labels += ["APG"]
             video_hq_sampler = configs.get("hq_sampler", 0)
             if video_hq_sampler:
-                video_rescale = configs.get("rescale_scale", configs.get("alt_scale", 0.0))
-                values += [f"Res2s (HQ), Rescale={video_rescale}"]
+                values += ["Res2s (HQ)"]
                 labels += ["Sampler"]
             video_motion_amplitude = configs.get("motion_amplitude", 1.)
             if  video_motion_amplitude != 1: 

--- a/wgp.py
+++ b/wgp.py
@@ -10564,7 +10564,7 @@ def generate_video_tab(update_form = False, state_dict = None, ui_defaults = Non
                             gr.Markdown("<B>Sampler</B>")
                             hq_sampler = gr.Dropdown(choices=[("Euler (Standard)", 0), ("Res2s (HQ)", 1)], value=ui_get("hq_sampler", 0), label="Sampler", scale=1)
                             with gr.Column(visible=(update_form and ui_get("hq_sampler", 0) == 1)) as hq_sampler_options:
-                                rescale_scale = gr.Slider(0, 1, value=ui_get("rescale_scale", 0.0), step=0.05, label="Rescale Scale (0=off, 0.45=recommended for HQ)", show_reset_button=False)
+                                rescale_scale = gr.Slider(0, 1, value=ui_get("rescale_scale", 0.45), step=0.05, label="Rescale Scale (0=off, 0.45=recommended for HQ)", show_reset_button=False)
                                 gr.Markdown("<I>Res2s HQ is designed for 15 steps with a distilled LoRA at 0.25 strength, CFG 3, Rescale 0.45</I>")
                             if not update_form:
                                 hq_sampler.change(fn=lambda v: gr.update(visible=v == 1), inputs=[hq_sampler], outputs=[hq_sampler_options])

--- a/wgp.py
+++ b/wgp.py
@@ -10944,7 +10944,7 @@ def generate_video_tab(update_form = False, state_dict = None, ui_defaults = Non
                                       NAG_col, audio_options_row, remove_background_sound, normalize_audio_volumes, speakers_locations_row, embedded_guidance_row, guidance_phases_row, guidance_row, resolution_group, cfg_free_guidance_col, control_net_weights_row, guide_selection_row, image_mode_tabs, prompt_enhancer_mode_dropdown, prompt_enhancer_think,
                                       min_frames_if_references_col, motion_amplitude_col, video_prompt_type_alignment, prompt_enhancer_btn, tab_inpaint, tab_t2v, resolution_row, loras_tab, post_processing_tab, temperature_row, *custom_settings_rows, top_pk_row, 
                                       number_frames_row, negative_prompt_row,
-                                      self_refiner_col, hq_sampler_col, pause_row]+\
+                                      self_refiner_col, hq_sampler_col, hq_sampler_options, pause_row]+\
                                       image_start_extra + image_end_extra + image_refs_extra #  presets_column,
         if update_form:
             locals_dict = locals()

--- a/wgp.py
+++ b/wgp.py
@@ -5835,6 +5835,8 @@ def generate_video(
     self_refiner_plan,
     self_refiner_f_uncertainty,
     self_refiner_certain_percentage,
+    hq_sampler,
+    rescale_scale,
     output_filename,
     state,
     model_type,
@@ -6715,6 +6717,8 @@ def generate_video(
                     self_refiner_plan=self_refiner_plan,
                     self_refiner_f_uncertainty = self_refiner_f_uncertainty,
                     self_refiner_certain_percentage = self_refiner_certain_percentage,
+                    hq_sampler=int(hq_sampler) if hq_sampler else 0,
+                    rescale_scale=float(rescale_scale) if rescale_scale else 0.0,
                     duration_seconds=duration_seconds,
                     pause_seconds=pause_seconds,
                     top_p=top_p,
@@ -8085,6 +8089,9 @@ def prepare_inputs_dict(target, inputs, model_type = None, model_filename = None
         pop += ["self_refiner_setting", "self_refiner_f_uncertainty", "self_refiner_plan", "self_refiner_certain_percentage"]
         # pop += ["self_refiner_setting", "self_refiner_plan"]
 
+    if not model_def.get("hq_sampler", False):
+        pop += ["hq_sampler", "rescale_scale"]
+
     if model_def.get("audio_scale_name", None) is None:
         pop += ["audio_scale"]
 
@@ -8809,6 +8816,8 @@ def save_inputs(
             self_refiner_plan,            
             self_refiner_f_uncertainty,
             self_refiner_certain_percentage,
+            hq_sampler,
+            rescale_scale,
             output_filename,
             mode,
             state,
@@ -10544,7 +10553,13 @@ def generate_video_tab(update_form = False, state_dict = None, ui_defaults = Non
                 any_motion_amplitude = model_def.get("motion_amplitude", False) and not image_outputs
                 any_pnp = True # Enable PnP for all supported models (or restriction logic here)
 
-                with gr.Tab("Quality", visible = (vace and image_outputs or any_perturbation or any_cfg_zero or any_cfg_star or any_apg or any_motion_amplitude or any_pnp) and not audio_only ) as quality_tab:
+                any_hq_sampler = model_def.get("hq_sampler", False)
+                with gr.Tab("Quality", visible = (vace and image_outputs or any_perturbation or any_cfg_zero or any_cfg_star or any_apg or any_motion_amplitude or any_pnp or any_hq_sampler) and not audio_only ) as quality_tab:
+                        with gr.Column(visible=any_hq_sampler) as hq_sampler_col:
+                            gr.Markdown("<B>Sampler (Res2s HQ uses a second-order sampler for better quality at fewer steps)</B>")
+                            with gr.Row():
+                                hq_sampler = gr.Dropdown(choices=[("Euler (Standard)", 0), ("Res2s (HQ)", 1)], value=ui_get("hq_sampler", 0), label="Sampler", scale=1)
+                                rescale_scale = gr.Slider(0, 1, value=ui_get("rescale_scale", 0.0), step=0.05, label="Rescale Scale (0=off, 0.45=recommended for HQ)", scale=2, show_reset_button=False)
                         with gr.Column(visible = any_perturbation ) as perturbation_row:
                             gr.Markdown("<B>Perturbation (improves video quality, requires guidance > 1)</B>")
                             perturbation_choices = model_def.get("perturbation_choices", [("OFF", 0), ("Skip Layer Guidance", 1)])
@@ -10926,7 +10941,7 @@ def generate_video_tab(update_form = False, state_dict = None, ui_defaults = Non
                                       NAG_col, audio_options_row, remove_background_sound, normalize_audio_volumes, speakers_locations_row, embedded_guidance_row, guidance_phases_row, guidance_row, resolution_group, cfg_free_guidance_col, control_net_weights_row, guide_selection_row, image_mode_tabs, prompt_enhancer_mode_dropdown, prompt_enhancer_think,
                                       min_frames_if_references_col, motion_amplitude_col, video_prompt_type_alignment, prompt_enhancer_btn, tab_inpaint, tab_t2v, resolution_row, loras_tab, post_processing_tab, temperature_row, *custom_settings_rows, top_pk_row, 
                                       number_frames_row, negative_prompt_row,
-                                      self_refiner_col, pause_row]+\
+                                      self_refiner_col, hq_sampler_col, pause_row]+\
                                       image_start_extra + image_end_extra + image_refs_extra #  presets_column,
         if update_form:
             locals_dict = locals()

--- a/wgp.py
+++ b/wgp.py
@@ -10562,7 +10562,7 @@ def generate_video_tab(update_form = False, state_dict = None, ui_defaults = Non
                         with gr.Column(visible=any_hq_sampler) as hq_sampler_col:
                             gr.Markdown("<B>Sampler</B>")
                             hq_sampler = gr.Dropdown(choices=[("Euler (Standard)", 0), ("Res2s (HQ)", 1)], value=ui_get("hq_sampler", 0), label="Sampler", scale=1)
-                            rescale_scale = gr.State(0.0)
+                            rescale_scale = gr.Number(value=0.0, visible=False)
                             with gr.Column(visible=(ui_get("hq_sampler", 0) == 1)) as hq_sampler_options:
                                 gr.Markdown("<I>Recommended settings for Res2s HQ: set Steps to 15, distilled LoRA multiplier to 0.25;0.5 (stage1;stage2), CFG to 3, Guidance Rescale to 0.45, Audio Guidance to 7, Modality Guidance to 3</I>")
                             if not update_form:

--- a/wgp.py
+++ b/wgp.py
@@ -10564,7 +10564,7 @@ def generate_video_tab(update_form = False, state_dict = None, ui_defaults = Non
                             gr.Markdown("<B>Sampler</B>")
                             hq_sampler = gr.Dropdown(choices=[("Euler (Standard)", 0), ("Res2s (HQ)", 1)], value=ui_get("hq_sampler", 0), label="Sampler", scale=1)
                             rescale_scale = gr.State(0.0)
-                            with gr.Column(visible=(update_form and ui_get("hq_sampler", 0) == 1)) as hq_sampler_options:
+                            with gr.Column(visible=(ui_get("hq_sampler", 0) == 1)) as hq_sampler_options:
                                 gr.Markdown("<I>Res2s HQ: 15 steps, distilled LoRA 0.25;0.5 (stage1;stage2), CFG 3, Guidance Rescale 0.45, Audio Guidance 7, Modality Guidance 3</I>")
                             if not update_form:
                                 hq_sampler.change(fn=lambda v: gr.update(visible=v == 1), inputs=[hq_sampler], outputs=[hq_sampler_options])

--- a/wgp.py
+++ b/wgp.py
@@ -10565,16 +10565,7 @@ def generate_video_tab(update_form = False, state_dict = None, ui_defaults = Non
                             rescale_scale = gr.Number(value=0.0, visible=False)
                             with gr.Column(visible=(ui_get("hq_sampler", 0) == 1)) as hq_sampler_options:
                                 gr.Markdown("<I>Recommended settings for Res2s HQ: set Steps to 15, distilled LoRA multiplier to 0.25;0.5 (stage1;stage2), CFG to 3, Guidance Rescale to 0.45, Audio Guidance to 7, Modality Guidance to 3</I>")
-                            if not update_form:
-                                def on_hq_sampler_change(v):
-                                    is_res2 = v == 1
-                                    return [
-                                        gr.update(visible=is_res2),   # hq_sampler_options (note)
-                                        gr.update(visible=not is_res2),  # apg_col
-                                        gr.update(visible=not is_res2),  # cfg_free_guidance_col
-                                        gr.update(visible=not is_res2),  # self_refiner_col
-                                    ]
-                                hq_sampler.change(fn=on_hq_sampler_change, inputs=[hq_sampler], outputs=[hq_sampler_options, apg_col, cfg_free_guidance_col, self_refiner_col])
+                            # hq_sampler.change registered after all Quality tab columns are defined
                         with gr.Column(visible = any_perturbation ) as perturbation_row:
                             gr.Markdown("<B>Perturbation (improves video quality, requires guidance > 1)</B>")
                             perturbation_choices = model_def.get("perturbation_choices", [("OFF", 0), ("Skip Layer Guidance", 1)])
@@ -10692,7 +10683,18 @@ def generate_video_tab(update_form = False, state_dict = None, ui_defaults = Non
                             with gr.Row():
                                 self_refiner_f_uncertainty = gr.Slider(0.0, 1.0, value=ui_get("self_refiner_f_uncertainty", 0.0), step=0.01, label="Uncertainty Threshold", show_reset_button= False)
                                 self_refiner_certain_percentage = gr.Slider(0.0, 1.0, value=ui_get("self_refiner_certain_percentage", 0.999), step=0.001, label="Certainty Percentage Skip", show_reset_button= False)
-                            
+
+                        # Register hq_sampler change handler now that all columns exist
+                        if not update_form and any_hq_sampler:
+                            def on_hq_sampler_change(v):
+                                is_res2 = v == 1
+                                return [
+                                    gr.update(visible=is_res2),      # hq_sampler_options (note)
+                                    gr.update(visible=not is_res2),  # apg_col
+                                    gr.update(visible=not is_res2),  # cfg_free_guidance_col
+                                    gr.update(visible=not is_res2),  # self_refiner_col
+                                ]
+                            hq_sampler.change(fn=on_hq_sampler_change, inputs=[hq_sampler], outputs=[hq_sampler_options, apg_col, cfg_free_guidance_col, self_refiner_col])
 
                 with gr.Tab("Sliding Window", visible= sliding_window_enabled and not image_outputs and not audio_only) as sliding_window_tab:
 

--- a/wgp.py
+++ b/wgp.py
@@ -4554,7 +4554,7 @@ def select_video(state, current_gallery_tab, input_file_list, file_selected, aud
                 labels += ["APG"]
             video_hq_sampler = configs.get("hq_sampler", 0)
             if video_hq_sampler:
-                video_rescale = configs.get("rescale_scale", 0.0)
+                video_rescale = configs.get("rescale_scale", configs.get("alt_scale", 0.0))
                 values += [f"Res2s (HQ), Rescale={video_rescale}"]
                 labels += ["Sampler"]
             video_motion_amplitude = configs.get("motion_amplitude", 1.)
@@ -8095,7 +8095,7 @@ def prepare_inputs_dict(target, inputs, model_type = None, model_filename = None
         # pop += ["self_refiner_setting", "self_refiner_plan"]
 
     if not model_def.get("hq_sampler", False):
-        pop += ["hq_sampler", "rescale_scale"]
+        pop += ["hq_sampler"]
 
     if model_def.get("audio_scale_name", None) is None:
         pop += ["audio_scale"]
@@ -10563,9 +10563,9 @@ def generate_video_tab(update_form = False, state_dict = None, ui_defaults = Non
                         with gr.Column(visible=any_hq_sampler) as hq_sampler_col:
                             gr.Markdown("<B>Sampler</B>")
                             hq_sampler = gr.Dropdown(choices=[("Euler (Standard)", 0), ("Res2s (HQ)", 1)], value=ui_get("hq_sampler", 0), label="Sampler", scale=1)
+                            rescale_scale = gr.State(0.0)
                             with gr.Column(visible=(update_form and ui_get("hq_sampler", 0) == 1)) as hq_sampler_options:
-                                rescale_scale = gr.Slider(0, 1, value=ui_get("rescale_scale", 0.45), step=0.05, label="Rescale Scale (0=off, 0.45=recommended for HQ)", show_reset_button=False)
-                                gr.Markdown("<I>Res2s HQ is designed for 15 steps with a distilled LoRA at 0.25;0.5 (stage1;stage2), CFG 3, Rescale 0.45</I>")
+                                gr.Markdown("<I>Res2s HQ: 15 steps, distilled LoRA 0.25;0.5 (stage1;stage2), CFG 3, Guidance Rescale 0.45, Audio Guidance 7, Modality Guidance 3</I>")
                             if not update_form:
                                 hq_sampler.change(fn=lambda v: gr.update(visible=v == 1), inputs=[hq_sampler], outputs=[hq_sampler_options])
                         with gr.Column(visible = any_perturbation ) as perturbation_row:

--- a/wgp.py
+++ b/wgp.py
@@ -10567,7 +10567,15 @@ def generate_video_tab(update_form = False, state_dict = None, ui_defaults = Non
                             with gr.Column(visible=(ui_get("hq_sampler", 0) == 1)) as hq_sampler_options:
                                 gr.Markdown("<I>Recommended settings for Res2s HQ: set Steps to 15, distilled LoRA multiplier to 0.25;0.5 (stage1;stage2), CFG to 3, Guidance Rescale to 0.45, Audio Guidance to 7, Modality Guidance to 3</I>")
                             if not update_form:
-                                hq_sampler.change(fn=lambda v: gr.update(visible=v == 1), inputs=[hq_sampler], outputs=[hq_sampler_options])
+                                def on_hq_sampler_change(v):
+                                    is_res2 = v == 1
+                                    return [
+                                        gr.update(visible=is_res2),   # hq_sampler_options (note)
+                                        gr.update(visible=not is_res2),  # apg_col
+                                        gr.update(visible=not is_res2),  # cfg_free_guidance_col
+                                        gr.update(visible=not is_res2),  # self_refiner_col
+                                    ]
+                                hq_sampler.change(fn=on_hq_sampler_change, inputs=[hq_sampler], outputs=[hq_sampler_options, apg_col, cfg_free_guidance_col, self_refiner_col])
                         with gr.Column(visible = any_perturbation ) as perturbation_row:
                             gr.Markdown("<B>Perturbation (improves video quality, requires guidance > 1)</B>")
                             perturbation_choices = model_def.get("perturbation_choices", [("OFF", 0), ("Skip Layer Guidance", 1)])
@@ -10593,7 +10601,7 @@ def generate_video_tab(update_form = False, state_dict = None, ui_defaults = Non
                                 perturbation_start_perc = gr.Slider(0, 100, value=ui_get("perturbation_start_perc"), step=1, label="Denoising Steps % start", show_reset_button= False)
                                 perturbation_end_perc = gr.Slider(0, 100, value=ui_get("perturbation_end_perc"), step=1, label="Denoising Steps % end", show_reset_button= False)
 
-                        with gr.Column(visible= any_apg ) as apg_col:
+                        with gr.Column(visible= any_apg and ui_get("hq_sampler", 0) != 1) as apg_col:
                             gr.Markdown("<B>Correct Progressive Color Saturation during long Video Generations")
                             apg_switch = gr.Dropdown(
                                 choices=[
@@ -10606,7 +10614,7 @@ def generate_video_tab(update_form = False, state_dict = None, ui_defaults = Non
                                 label="Adaptive Projected Guidance (requires Guidance > 1 or Audio Guidance > 1) " if multitalk else "Adaptive Projected Guidance (requires Guidance > 1)",
                             )
 
-                        with gr.Column(visible = any_cfg_star) as cfg_free_guidance_col:
+                        with gr.Column(visible = any_cfg_star and ui_get("hq_sampler", 0) != 1) as cfg_free_guidance_col:
                             gr.Markdown("<B>Classifier-Free Guidance Zero Star, better adherence to Text Prompt")
                             cfg_star_switch = gr.Dropdown(
                                 choices=[
@@ -10645,7 +10653,7 @@ def generate_video_tab(update_form = False, state_dict = None, ui_defaults = Non
                             gr.Markdown("<B>Experimental: Accelerate Motion (1: disabled, 1.15 recommended)")
                             motion_amplitude  = gr.Slider(1, 1.4, value=ui_get("motion_amplitude"), step=0.01, label="Motion Amplitude", visible = True, show_reset_button= False) 
 
-                        with gr.Column(visible = model_def.get("self_refiner", False)) as self_refiner_col:
+                        with gr.Column(visible = model_def.get("self_refiner", False) and ui_get("hq_sampler", 0) != 1) as self_refiner_col:
                             gr.Markdown("<B>Self-Refining Video Sampling (PnP) - should improve quality of Motion</B>")
                             self_refiner_setting = gr.Dropdown(choices=[("Disabled", 0),("Enabled with P1-Norm", 1), ("Enabled with P2-Norm", 2)], value=ui_get("self_refiner_setting", 0), scale=1, label="Self Refiner")
                             

--- a/wgp.py
+++ b/wgp.py
@@ -10565,7 +10565,7 @@ def generate_video_tab(update_form = False, state_dict = None, ui_defaults = Non
                             hq_sampler = gr.Dropdown(choices=[("Euler (Standard)", 0), ("Res2s (HQ)", 1)], value=ui_get("hq_sampler", 0), label="Sampler", scale=1)
                             rescale_scale = gr.State(0.0)
                             with gr.Column(visible=(ui_get("hq_sampler", 0) == 1)) as hq_sampler_options:
-                                gr.Markdown("<I>Res2s HQ: 15 steps, distilled LoRA 0.25;0.5 (stage1;stage2), CFG 3, Guidance Rescale 0.45, Audio Guidance 7, Modality Guidance 3</I>")
+                                gr.Markdown("<I>Recommended settings for Res2s HQ: set Steps to 15, distilled LoRA multiplier to 0.25;0.5 (stage1;stage2), CFG to 3, Guidance Rescale to 0.45, Audio Guidance to 7, Modality Guidance to 3</I>")
                             if not update_form:
                                 hq_sampler.change(fn=lambda v: gr.update(visible=v == 1), inputs=[hq_sampler], outputs=[hq_sampler_options])
                         with gr.Column(visible = any_perturbation ) as perturbation_row:

--- a/wgp.py
+++ b/wgp.py
@@ -10565,7 +10565,7 @@ def generate_video_tab(update_form = False, state_dict = None, ui_defaults = Non
                             hq_sampler = gr.Dropdown(choices=[("Euler (Standard)", 0), ("Res2s (HQ)", 1)], value=ui_get("hq_sampler", 0), label="Sampler", scale=1)
                             with gr.Column(visible=(update_form and ui_get("hq_sampler", 0) == 1)) as hq_sampler_options:
                                 rescale_scale = gr.Slider(0, 1, value=ui_get("rescale_scale", 0.45), step=0.05, label="Rescale Scale (0=off, 0.45=recommended for HQ)", show_reset_button=False)
-                                gr.Markdown("<I>Res2s HQ is designed for 15 steps with a distilled LoRA at 0.25 strength, CFG 3, Rescale 0.45</I>")
+                                gr.Markdown("<I>Res2s HQ is designed for 15 steps with a distilled LoRA at 0.25;0.5 (stage1;stage2), CFG 3, Rescale 0.45</I>")
                             if not update_form:
                                 hq_sampler.change(fn=lambda v: gr.update(visible=v == 1), inputs=[hq_sampler], outputs=[hq_sampler_options])
                         with gr.Column(visible = any_perturbation ) as perturbation_row:


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary

Ports the official `TI2VidTwoStagesHQPipeline` components from Lightricks' LTX-2 reference implementation, adding a Res2s (HQ) sampler option for the LTX2 dev pipeline.

- **Res2sDiffusionStep**: Second-order sampler with SDE noise injection and variance-preserving transitions
- **res2s_audio_video_denoising_loop**: Two-stage Runge-Kutta denoising loop with bong iteration for anchor stabilization
- **MultiModalGuider**: Unified guidance combining CFG, STG, modality guidance, and rescaling in one pass
- **Resolution-dependent sigma scheduling**: Passes latent shape to scheduler for correct sigma shifting (HQ path only, Euler path unchanged)

### UI
- Sampler dropdown in Quality tab: `Euler (Standard)` / `Res2s (HQ)`
- Rescale Scale slider (0-1, 0.45 recommended)
- Info note with recommended settings
- Visible for dev pipeline only (not distilled)

### Official HQ defaults
- 15 steps, CFG 3.0, Rescale 0.45, Distilled LoRA at 0.25 strength
- Audio rescale hardcoded to 1.0 (per official)

### What's unchanged
- Euler path is completely untouched — selecting Euler gives identical behavior to before this PR
- All existing Quality tab settings (perturbation, APG, CFG Star, Self Refiner) work as before with Euler
- Distilled pipeline unaffected

### Known limitations
- No per-stage LoRA strength (official uses 0.25 stage 1, 0.5 stage 2 for distilled LoRA)
- Self Refiner not integrated with Res2s loop (only works with Euler)
- Image CRF preprocessing not implemented (official pre-compresses conditioning images at CRF=33)

### Files changed
- `models/ltx2/ltx_core/components/diffusion_steps.py` — Res2sDiffusionStep
- `models/ltx2/ltx_core/components/guiders.py` — MultiModalGuider + MultiModalGuiderParams
- `models/ltx2/ltx_pipelines/utils/res2s.py` — phi functions and RK coefficients (new file)
- `models/ltx2/ltx_pipelines/utils/helpers.py` — res2s loop, multi_modal_guider_denoising_func, SDE noise helpers
- `models/ltx2/ltx_pipelines/ti2vid_two_stages.py` — HQ path branching, sigma schedule, stepper/guider selection
- `models/ltx2/ltx2.py` — forward hq_sampler/rescale_scale params
- `models/ltx2/ltx2_handler.py` — hq_sampler capability flag for dev models
- `wgp.py` — UI controls, param threading

## Test plan
- [ ] Verify Euler (Standard) produces identical output to main branch
- [ ] Verify Res2s (HQ) completes generation without errors (both stages)
- [ ] Test with distilled LoRA at 0.25 strength, 15 steps, CFG 3, rescale 0.45
- [ ] Test without distilled LoRA at 20+ steps
- [ ] Test distilled pipeline still works (HQ option not visible)
- [ ] Verify settings save/load correctly with hq_sampler and rescale_scale

🤖 Generated with [Claude Code](https://claude.com/claude-code)