### PR TITLE
Disable torch.compile for Cocktail models to fix noisy output

### DIFF
--- a/defaults/vace_14B_cocktail.json
+++ b/defaults/vace_14B_cocktail.json
@@ -1,7 +1,7 @@
 {
     "model": {
         "name": "Vace Cocktail 14B",
-        "architecture": "vace_14B",
+        "compile": false,        "architecture": "vace_14B",
         "modules": [
             "vace_14B"
         ],

--- a/defaults/vace_14B_cocktail_2_2.json
+++ b/defaults/vace_14B_cocktail_2_2.json
@@ -1,7 +1,7 @@
 {
     "model": {
         "name": "Wan2.2 Vace Experimental Cocktail 14B",
-        "architecture": "vace_14B_2_2",
+        "compile": false,        "architecture": "vace_14B_2_2",
         "modules": [
             "vace_14B"
         ],

--- a/defaults/vace_fun_14B_cocktail_2_2.json
+++ b/defaults/vace_fun_14B_cocktail_2_2.json
@@ -1,7 +1,7 @@
 {
     "model": {
         "name": "Wan2.2 Vace Fun Cocktail 14B",
-        "architecture": "vace_14B_2_2",
+        "compile": false,        "architecture": "vace_14B_2_2",
         "description": "This model has been created on the fly using the Wan text 2.2 video model and the Loras of FusioniX. The weight of the Detail Enhancer Lora has been reduced to improve identity preservation. This is the Fun Vace 2.2, that is not the official Vace 2.2",
         "URLs": "vace_fun_14B_2_2",
         "URLs2": "vace_fun_14B_2_2",


### PR DESCRIPTION
## Summary
- Cocktail models produce un-denoised (noisy) output when `torch.compile` is enabled. This is caused by the inductor backend incorrectly specializing the compiled LoRA forward graph when multiple LoRAs have different alpha/rank scaling values (DetailEnhancer has alpha_scale=0.03125 vs 1.0 for CausVid/AccVid/MoviiGen).
- The regression was introduced in mmgp 3.6.11 (WanGP v10.10) when the LoRA forward was changed from per-module closures to a single module-level function for torch.compile compatibility.

## Fix
- Add `"compile": false` to all three Cocktail model definitions, disabling compilation only for these models while keeping it enabled globally for all others.