### PR TITLE
Guard `torch.distributed` submodule imports for ROCm builds

### DIFF
--- a/models/kandinsky5/kandinsky/models/parallelize.py
+++ b/models/kandinsky5/kandinsky/models/parallelize.py
@@ -1,12 +1,17 @@
-from torch.distributed._tensor import Replicate, Shard
-from torch.distributed.tensor.parallel import (
-    ColwiseParallel,
-    PrepareModuleInput,
-    PrepareModuleOutput,
-    RowwiseParallel,
-    SequenceParallel,
-    parallelize_module,
-)
+try:
+    from torch.distributed._tensor import Replicate, Shard
+    from torch.distributed.tensor.parallel import (
+        ColwiseParallel,
+        PrepareModuleInput,
+        PrepareModuleOutput,
+        RowwiseParallel,
+        SequenceParallel,
+        parallelize_module,
+    )
+except (ImportError, ModuleNotFoundError):
+    Replicate = Shard = None
+    ColwiseParallel = PrepareModuleInput = PrepareModuleOutput = None
+    RowwiseParallel = SequenceParallel = parallelize_module = None
 
 
 def parallelize_dit(model, tp_mesh):

--- a/models/wan/any2video.py
+++ b/models/wan/any2video.py
@@ -14,13 +14,19 @@ from mmgp import offload
 import torch
 import torch.nn as nn
 import torch.cuda.amp as amp
-import torch.distributed as dist
+try:
+    import torch.distributed as dist
+except ImportError:
+    dist = None
 import numpy as np
 from tqdm import tqdm
 from PIL import Image
 import torchvision.transforms.functional as TF
 import torch.nn.functional as F
-from .distributed.fsdp import shard_model
+try:
+    from .distributed.fsdp import shard_model
+except (ImportError, ModuleNotFoundError):
+    shard_model = None
 from .modules.model import WanModel
 from mmgp.offload import get_cache, clear_caches
 from .modules.t5 import T5EncoderModel

--- a/models/wan/multitalk/multitalk.py
+++ b/models/wan/multitalk/multitalk.py
@@ -1,7 +1,10 @@
 import random
 import os
 import torch
-import torch.distributed as dist
+try:
+    import torch.distributed as dist
+except ImportError:
+    dist = None
 from PIL import Image
 import subprocess
 import torchvision.transforms as transforms


### PR DESCRIPTION
## Problem

On Windows ROCm via TheRock, the `torch._C._distributed_c10d` C-extension is not shipped. `torch.distributed` itself is present as a stub, but importing any submodule that touches c10d bindings - `torch.distributed.fsdp`, `torch.distributed._tensor`, `torch.distributed.tensor.parallel` - raises at import time:

```
ModuleNotFoundError: No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package
```

Wan2GP hits this at startup because `models/wan/any2video.py` unconditionally imports `shard_model` from `models/wan/distributed/fsdp.py`, which pulls in `torch.distributed.fsdp` at module top. Full traceback ends at:

```
File "Wan2GP/models/wan/distributed/fsdp.py", line 5, in <module>
    from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
...
ModuleNotFoundError: No module named 'torch._C._distributed_c10d'
```

This blocks Wan2GP from starting at all on AMD + TheRock, even for single-GPU inference where distributed is never used.

## Fix

Wrap the affected top-level imports in `try`/`except (ImportError, ModuleNotFoundError)`, falling back to `None` when the submodule cannot be loaded. Behavior on CUDA and on ROCm builds that ship c10d is unchanged - the imports succeed and the bound names are identical.

Changed files:

- `models/wan/any2video.py` - guard `import torch.distributed as dist` and `from .distributed.fsdp import shard_model`.
- `models/wan/multitalk/multitalk.py` - guard `import torch.distributed as dist`. Imported lazily from `any2video.py`, so this path only triggers when multitalk features are used, but fails for the same reason.
- `models/kandinsky5/kandinsky/models/parallelize.py` - guard `torch.distributed._tensor` and `torch.distributed.tensor.parallel` imports.

Plain `import torch.distributed as dist` statements elsewhere in the repo (hyvideo, nanovllm, mmaudio, TTS, magi_human, longcat, radial_attention) were not changed - the bare namespace imports succeed on TheRock; only submodule imports that touch c10d fail.

## Verification

Reproduced on `torch 2.12.0a0+rocm7.13.0a` (TheRock), Windows 11, Python 3.12:

- Before: `python wgp.py` crashes at import with the traceback above.
- After: Wan2GP starts successfully. `shard_model`, `dist`, and the kandinsky tensor-parallel symbols resolve to `None`; no code path in single-GPU inference references them.
- On CUDA PyTorch (verified separately): no behavior change - try-blocks succeed and bindings are identical.

## Resolves

- https://github.com/deepbeepmeep/Wan2GP/issues/1210
- https://github.com/deepbeepmeep/Wan2GP/issues/1362
- https://github.com/deepbeepmeep/Wan2GP/issues/1357

cc @deepbeepmeep @Tophness 