### PR TITLE
Option to run Wan2GP as a desktop app

### DIFF
--- a/shared/cli_args.py
+++ b/shared/cli_args.py
@@ -61,6 +61,7 @@ def parse_wgp_args(family_handlers: Sequence[str], config_filename: str, default
     add("--server-name", type=str, default="", help="Server name")
     add("--gpu", type=str, default="", help="Default GPU Device")
     add("--open-browser", action="store_true", help="open browser")
+    add("--run-as-chrome-app", type=str, default="", help="open as app using provided chrome exe location")
     add("--t2v", action="store_true", help="text to video mode")
     add("--i2v", action="store_true", help="image to video mode")
     add("--t2v-14B", action="store_true", help="text to video mode 14B model")

--- a/wgp.py
+++ b/wgp.py
@@ -12182,7 +12182,8 @@ if __name__ == "__main__":
             quit_application()
         
         chrome_exe=args.run_as_chrome_app
-        run_chrome([chrome_exe, "--app="+url], finish)
+        profile=os.path.join( Path.cwd(), "appModeProfile")        
+        run_chrome([chrome_exe,"--user-data-dir="+profile, "--app="+url], finish)
     if args.open_browser:
         import webbrowser       
         webbrowser.open(url, new = 0, autoraise = True)

--- a/wgp.py
+++ b/wgp.py
@@ -1795,6 +1795,10 @@ def clear_queue_action(state):
 def quit_application():
     print("Save and Quit requested...")
     clear_startup_lock()
+    global chrome_proc
+    if chrome_proc:
+        chrome_proc.kill()
+        chrome_proc = None
     autosave_queue()
     import signal
     os.kill(os.getpid(), signal.SIGINT)
@@ -12152,14 +12156,36 @@ if __name__ == "__main__":
     if len(server_name) == 0:
         server_name = os.getenv("SERVER_NAME", "localhost")
     demo = create_ui()
-    clear_startup_lock()
+    clear_startup_lock() 
+    if server_name.startswith("http"):
+        url = server_name
+    else:
+        url = "http://" + server_name
+    url= url + ":" + str(server_port)   
+    if len(args.run_as_chrome_app) >0:
+        def run_chrome(command, callback):
+            import subprocess
+            def cleanup():
+                    global chrome_proc
+                    print("Cleaning up Chrome...")
+                    chrome_proc.kill()
+            def target():
+                global chrome_proc
+                chrome_proc = subprocess.Popen(command)
+                chrome_proc.communicate()                
+                callback()
+            atexit.register(cleanup)
+            thread = threading.Thread(target=target,daemon=True)
+            thread.start()
+        def finish():            
+            print("App has been closed, shutting down server...")
+            quit_application()
+        
+        chrome_exe=args.run_as_chrome_app
+        run_chrome([chrome_exe, "--app="+url], finish)
     if args.open_browser:
-        import webbrowser
-        if server_name.startswith("http"):
-            url = server_name
-        else:
-            url = "http://" + server_name
-        webbrowser.open(url + ":" + str(server_port), new = 0, autoraise = True)
+        import webbrowser       
+        webbrowser.open(url, new = 0, autoraise = True)
     demo.launch(
         favicon_path="favicon.png",
         server_name=server_name,


### PR DESCRIPTION
If you pass the parameter --app=<url> to the chrome exe it will start a new instance of chrome without any of the browser UI making it appear like a normal app. 

This PR adds a new CLI arg  "--run-as-chrome-app" which takes the location of the chrome exe 
When the server is started it will open the url in app mode. 
I also added some basic cleanup so if you close the app it will stop the server and if you stop the server it will close the app. 

The beauty of this is that you can now launch Wan2GP in a single step. 

For Instance I made a launch.bat file with the text
`start "Wan2GP Console" <conda_location>\conda.exe run --live-stream -n wan2gp python wgp.py --run-as-chrome-app "C:\Program Files\Google\Chrome\Application\chrome.exe"`

(This starts a console with the title "Wan2GP Console" and than loads the app using conda)

<img width="1473" height="1306" alt="Wan2gp_as_app" src="https://github.com/user-attachments/assets/a2614666-7566-4e51-94ed-6d4ad6d241cc" />
<img width="2316" height="1449" alt="image" src="https://github.com/user-attachments/assets/e820366d-4cb6-4abb-93fc-169a8014f481" />

