### PR TITLE
Z-Image inpainting controls via LanPaint

### DIFF
--- a/models/z_image/pipeline_z_image.py
+++ b/models/z_image/pipeline_z_image.py
@@ -409,6 +409,8 @@ class ZImagePipeline(DiffusionPipeline, FromSingleFileMixin):
         NAG_tau: float = 3.5,
         NAG_alpha: float = 0.5,
         loras_slists = None,
+        model_mode_int: int = 0,
+        lanpaint_enabled: bool = False,
     ):
         r"""
         Function invoked when calling the pipeline for generation.
@@ -672,6 +674,66 @@ class ZImagePipeline(DiffusionPipeline, FromSingleFileMixin):
                 # v1 control: just use the control latent directly (16 channels)
                 control_latent_input = control_latent.unsqueeze(2)
 
+        # LanPaint preparation
+        lanpaint_proc = None
+        lanpaint_mask = None
+        original_image_latents = None
+        randn = None
+
+        if lanpaint_enabled and control_image is not None and inpaint_mask is not None and not use_unified:
+            # Convert control image to tensor [B, C, H, W]
+            lp_image = control_image
+            if lp_image.dim() == 4 and lp_image.shape[1] == 1:
+                lp_image = lp_image.squeeze(1).unsqueeze(0)
+            elif lp_image.dim() == 3:
+                lp_image = lp_image.unsqueeze(0)
+            lp_image = lp_image.to(device=device, dtype=self.vae.dtype)
+
+            # Encode original image to latents
+            original_image_latents = self.vae.encode(lp_image).latent_dist.mode()
+            original_image_latents = (original_image_latents - self.vae.config.shift_factor) * self.vae.config.scaling_factor
+
+            # Store initial noise
+            randn = latents.clone()
+
+            # Build mask in packed latent space
+            lp_mask = inpaint_mask.to(device=device, dtype=torch.float32)
+            if lp_mask.dim() == 3:
+                lp_mask = lp_mask.unsqueeze(0)
+            if lp_mask.dim() == 4 and lp_mask.shape[1] > 1:
+                lp_mask = lp_mask[:, :1]
+
+            # Downsample to latent resolution
+            latent_h, latent_w = latents.shape[-2], latents.shape[-1]
+            if lp_mask.shape[-2:] != (latent_h, latent_w):
+                lp_mask = torch.nn.functional.interpolate(lp_mask, size=(latent_h, latent_w), mode='nearest')
+            lp_mask = (lp_mask > 0.5).float()
+
+            # Ensure batch size matches latents
+            if lp_mask.shape[0] == 1 and latents.shape[0] > 1:
+                lp_mask = lp_mask.expand(latents.shape[0], -1, -1, -1)
+
+            # Pack: [B, 1, H_latent, W_latent] -> [B, 1, 1, H_latent, W_latent] -> pack -> [B, seq, 4]
+            lp_mask = lp_mask.unsqueeze(2)
+            from shared.inpainting.lanpaint import _pack_latents
+            lanpaint_mask = _pack_latents(lp_mask)
+
+            # Pack original latents and noise
+            original_image_latents = _pack_latents(original_image_latents.unsqueeze(2))
+            randn = _pack_latents(randn.unsqueeze(2))
+            if original_image_latents.shape[0] == 1 and latents.shape[0] > 1:
+                original_image_latents = original_image_latents.expand(latents.shape[0], -1, -1)
+                randn = randn.expand(latents.shape[0], -1, -1)
+
+            # Instantiate LanPaint
+            from shared.inpainting.lanpaint import LanPaint
+            lanpaint_steps = {2: 2, 3: 5, 4: 10, 5: 15}.get(model_mode_int, 5)
+            lanpaint_proc = LanPaint(
+                NSteps=lanpaint_steps,
+                IS_FLUX=False,
+                IS_FLOW=True,
+            )
+
         if use_unified:
             unified_cfg = _resolve_unified_sampler_config(sample_solver, num_inference_steps, unified_sampler_config)
             sampler = UnifiedSampler()
@@ -873,6 +935,7 @@ class ZImagePipeline(DiffusionPipeline, FromSingleFileMixin):
                             latents_preview = latents_preview.transpose(0, 2)
                         callback(i, latents_preview[0], False)
                         latents_preview = None
+                    progress_bar.update(1)
 
             if self._interrupt or final_x_hat is None:
                 return None
@@ -883,6 +946,61 @@ class ZImagePipeline(DiffusionPipeline, FromSingleFileMixin):
 
             if hasattr(self.transformer, 'loras_slists') and self.transformer.loras_slists is not None:
                 update_loras_slists(self.transformer, self.transformer.loras_slists, len(timesteps))
+
+            # LanPaint helper functions for default scheduler path
+            if lanpaint_proc is not None:
+                from shared.inpainting.lanpaint import _pack_latents, _unpack_latents
+                lp_state = {"t": None}
+
+                def zimage_denoise(lp_latents_packed, lp_cfg_scale):
+                    lp_latents = _unpack_latents(lp_latents_packed, height=height, width=width, vae_scale_factor=self.vae_scale_factor)
+                    lp_t = lp_state["t"]
+                    lp_timestep = lp_t.expand(lp_latents.shape[0])
+                    lp_timestep = (1000 - lp_timestep) / 1000
+                    lp_apply_cfg = self.do_classifier_free_guidance and lp_cfg_scale > 0
+                    if lp_apply_cfg:
+                        lp_out = self.transformer(
+                            [lp_latents, lp_latents],
+                            lp_timestep,
+                            [prompt_embeds[0], negative_prompt_embeds[0]],
+                            control_context_list=[control_latent_input, control_latent_input] if control_latent_input is not None else None,
+                            control_context_scale=control_context_scale,
+                            callback=None,
+                            pipeline=self,
+                            **kwargs,
+                        )
+                        if lp_out is None:
+                            return None, None
+                        lp_pos, lp_neg = lp_out
+                    else:
+                        lp_out = self.transformer(
+                            [lp_latents],
+                            lp_timestep,
+                            [prompt_embeds[0]],
+                            control_context_list=[control_latent_input] if control_latent_input is not None else None,
+                            control_context_scale=control_context_scale,
+                            callback=None,
+                            pipeline=self,
+                            **kwargs,
+                        )
+                        if lp_out is None:
+                            return None, None
+                        lp_pos = lp_out[0]
+                        lp_neg = None
+                    # Z-Image transformer outputs negative velocity; negate to match LanPaint's flow expectation
+                    lp_pos = -lp_pos
+                    if lp_neg is not None:
+                        lp_neg = -lp_neg
+                    lp_pos = _pack_latents(lp_pos)
+                    if lp_neg is not None:
+                        lp_neg = _pack_latents(lp_neg)
+                    return lp_pos, lp_neg
+
+                def zimage_cfg_predictions(lp_pos, lp_neg, lp_scale, lp_t):
+                    if lp_neg is None or lp_scale <= 1:
+                        return lp_pos
+                    lp_pred = lp_pos + lp_scale * (lp_pos - lp_neg)
+                    return lp_pred
 
             with self.progress_bar(total=num_inference_steps) as progress_bar:
                 for i, t in enumerate(timesteps):
@@ -904,6 +1022,31 @@ class ZImagePipeline(DiffusionPipeline, FromSingleFileMixin):
                             current_guidance_scale = 0.0
 
                     apply_cfg = self.do_classifier_free_guidance and current_guidance_scale > 0
+
+                    # ===== LANPAINT HOOK =====
+                    if lanpaint_proc is not None and i < len(timesteps) - 1:
+                        lp_state["t"] = t
+                        latents_packed = _pack_latents(latents.unsqueeze(2))
+                        # Normalize raw scheduler timestep to [0,1] flow time for LanPaint
+                        flow_t = t / self.scheduler.config.num_train_timesteps
+                        latents_packed = lanpaint_proc(
+                            denoise=zimage_denoise,
+                            cfg_predictions=zimage_cfg_predictions,
+                            true_cfg_scale=self.guidance_scale,
+                            cfg_BIG=1.0,
+                            x=latents_packed,
+                            latent_image=original_image_latents,
+                            noise=randn,
+                            sigma=flow_t,
+                            latent_mask=lanpaint_mask,
+                            height=height,
+                            width=width,
+                            vae_scale_factor=self.vae_scale_factor,
+                        )
+                        if latents_packed is None:
+                            return None
+                        latents = _unpack_latents(latents_packed, height=height, width=width, vae_scale_factor=self.vae_scale_factor).squeeze(2)
+                    # ===== END LANPAINT HOOK =====
 
                     latent_model_input = latents if latents.dtype == dtype else latents.to(dtype)
                     latent_model_input = latent_model_input.unsqueeze(2)
@@ -967,7 +1110,7 @@ class ZImagePipeline(DiffusionPipeline, FromSingleFileMixin):
                             latents_preview = latents_preview.transpose(0, 2)
                         callback(i, latents_preview[0], False)
                         latents_preview = None
-
+                    progress_bar.update(1)
 
         if self._interrupt:
             return None

--- a/models/z_image/pipeline_z_image.py
+++ b/models/z_image/pipeline_z_image.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import inspect
+import math
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import torch
@@ -411,6 +412,8 @@ class ZImagePipeline(DiffusionPipeline, FromSingleFileMixin):
         loras_slists = None,
         model_mode_int: int = 0,
         lanpaint_enabled: bool = False,
+        denoising_strength: float = 1.0,
+        masking_strength: float = 1.0,
     ):
         r"""
         Function invoked when calling the pipeline for generation.
@@ -674,51 +677,47 @@ class ZImagePipeline(DiffusionPipeline, FromSingleFileMixin):
                 # v1 control: just use the control latent directly (16 channels)
                 control_latent_input = control_latent.unsqueeze(2)
 
-        # LanPaint preparation
+        # Shared inpainting resources (used by LanPaint and/or latent-level masking)
         lanpaint_proc = None
         lanpaint_mask = None
         original_image_latents = None
         randn = None
+        inpaint_mask_latents = None
 
-        if lanpaint_enabled and control_image is not None and inpaint_mask is not None and not use_unified:
+        if control_image is not None and inpaint_mask is not None:
             # Convert control image to tensor [B, C, H, W]
-            lp_image = control_image
-            if lp_image.dim() == 4 and lp_image.shape[1] == 1:
-                lp_image = lp_image.squeeze(1).unsqueeze(0)
-            elif lp_image.dim() == 3:
-                lp_image = lp_image.unsqueeze(0)
-            lp_image = lp_image.to(device=device, dtype=self.vae.dtype)
+            orig_image = control_image
+            if orig_image.dim() == 4 and orig_image.shape[1] == 1:
+                orig_image = orig_image.squeeze(1).unsqueeze(0)
+            elif orig_image.dim() == 3:
+                orig_image = orig_image.unsqueeze(0)
+            orig_image = orig_image.to(device=device, dtype=self.vae.dtype)
 
             # Encode original image to latents
-            original_image_latents = self.vae.encode(lp_image).latent_dist.mode()
+            original_image_latents = self.vae.encode(orig_image).latent_dist.mode()
             original_image_latents = (original_image_latents - self.vae.config.shift_factor) * self.vae.config.scaling_factor
 
             # Store initial noise
             randn = latents.clone()
 
-            # Build mask in packed latent space
-            lp_mask = inpaint_mask.to(device=device, dtype=torch.float32)
-            if lp_mask.dim() == 3:
-                lp_mask = lp_mask.unsqueeze(0)
-            if lp_mask.dim() == 4 and lp_mask.shape[1] > 1:
-                lp_mask = lp_mask[:, :1]
+            # Build latent-resolution mask for latent-level masking
+            m = inpaint_mask.to(device=device, dtype=torch.float32)
+            if m.dim() == 3:
+                m = m.unsqueeze(0)
+            if m.dim() == 4 and m.shape[1] > 1:
+                m = m[:, :1]
+            if m.shape[-2:] != latents.shape[-2:]:
+                m = torch.nn.functional.interpolate(m, size=latents.shape[-2:], mode='nearest')
+            m = (m > 0.5).float()
+            if m.shape[0] == 1 and latents.shape[0] > 1:
+                m = m.expand(latents.shape[0], -1, -1, -1)
+            inpaint_mask_latents = m.to(latents.dtype)
 
-            # Downsample to latent resolution
-            latent_h, latent_w = latents.shape[-2], latents.shape[-1]
-            if lp_mask.shape[-2:] != (latent_h, latent_w):
-                lp_mask = torch.nn.functional.interpolate(lp_mask, size=(latent_h, latent_w), mode='nearest')
-            lp_mask = (lp_mask > 0.5).float()
-
-            # Ensure batch size matches latents
-            if lp_mask.shape[0] == 1 and latents.shape[0] > 1:
-                lp_mask = lp_mask.expand(latents.shape[0], -1, -1, -1)
-
-            # Pack: [B, 1, H_latent, W_latent] -> [B, 1, 1, H_latent, W_latent] -> pack -> [B, seq, 4]
-            lp_mask = lp_mask.unsqueeze(2)
+        if lanpaint_enabled and control_image is not None and inpaint_mask is not None and not use_unified:
+            # Reuse already-built original_image_latents, randn, and inpaint_mask_latents
             from shared.inpainting.lanpaint import _pack_latents
-            lanpaint_mask = _pack_latents(lp_mask)
+            lanpaint_mask = _pack_latents(inpaint_mask_latents.unsqueeze(2))
 
-            # Pack original latents and noise
             original_image_latents = _pack_latents(original_image_latents.unsqueeze(2))
             randn = _pack_latents(randn.unsqueeze(2))
             if original_image_latents.shape[0] == 1 and latents.shape[0] > 1:
@@ -766,6 +765,8 @@ class ZImagePipeline(DiffusionPipeline, FromSingleFileMixin):
             callback(-1, None, True, total_steps)
             if hasattr(self.transformer, 'loras_slists') and self.transformer.loras_slists is not None:
                 update_loras_slists(self.transformer, self.transformer.loras_slists, total_steps)
+
+            masked_steps = math.ceil(total_steps * masking_strength) if inpaint_mask_latents is not None else 0
 
             def model_fn(x_t, t, tt=None):
                 if self._interrupt:
@@ -927,6 +928,12 @@ class ZImagePipeline(DiffusionPipeline, FromSingleFileMixin):
 
                     x_cur = x_next
 
+                    # Apply masking_strength constraint (latent-level masked denoising)
+                    if inpaint_mask_latents is not None and i < masked_steps:
+                        noise_level = t_cur.abs()
+                        noisy_original = original_image_latents * (1.0 - noise_level) + randn * noise_level
+                        x_cur = noisy_original * (1.0 - inpaint_mask_latents) + inpaint_mask_latents * x_cur
+
                     if self._interrupt:
                         break
                     if callback is not None and final_x_hat is not None:
@@ -946,6 +953,18 @@ class ZImagePipeline(DiffusionPipeline, FromSingleFileMixin):
 
             if hasattr(self.transformer, 'loras_slists') and self.transformer.loras_slists is not None:
                 update_loras_slists(self.transformer, self.transformer.loras_slists, len(timesteps))
+
+            # Apply denoising_strength (img2img-style partial denoising)
+            # Note: LanPaint handles its own masking/denoising logic; skip these when LanPaint is active
+            if denoising_strength < 1.0 and original_image_latents is not None and not lanpaint_enabled:
+                first_step = int(len(timesteps[:-1]) * (1.0 - denoising_strength))
+                if first_step > 0:
+                    noise_level = timesteps[first_step] / self.scheduler.config.num_train_timesteps
+                    latents = original_image_latents * (1.0 - noise_level) + randn * noise_level
+                    timesteps = timesteps[first_step:]
+                    num_inference_steps = len(timesteps)
+
+            masked_steps = math.ceil(len(timesteps[:-1]) * masking_strength) if inpaint_mask_latents is not None and not lanpaint_enabled else 0
 
             # LanPaint helper functions for default scheduler path
             if lanpaint_proc is not None:
@@ -1101,6 +1120,12 @@ class ZImagePipeline(DiffusionPipeline, FromSingleFileMixin):
 
                     latents = self.scheduler.step(noise_pred.to(torch.float32), t, latents, return_dict=False)[0]
                     assert latents.dtype == torch.float32
+
+                    # Apply masking_strength constraint (latent-level masked denoising)
+                    if inpaint_mask_latents is not None and i < masked_steps and not lanpaint_enabled:
+                        noise_level = t / self.scheduler.config.num_train_timesteps
+                        noisy_original = original_image_latents * (1.0 - noise_level) + randn * noise_level
+                        latents = noisy_original * (1.0 - inpaint_mask_latents) + inpaint_mask_latents * latents
 
                     if self._interrupt:
                         break

--- a/models/z_image/z_image_handler.py
+++ b/models/z_image/z_image_handler.py
@@ -32,6 +32,12 @@ class family_handler:
             extra_model_def["inpaint_support"] = True
             extra_model_def["inpaint_video_prompt_type"] = "VA"
             extra_model_def["image_video_prompt_type"] = ""
+            extra_model_def["mask_strength_always_enabled"] = True
+            extra_model_def["video_guide_outpainting"] = [1, 2]
+            extra_model_def["mask_preprocessing"] = {
+                "selection": ["", "A", "NA"],
+                "visible": True,
+            }
             extra_model_def["model_modes"] = {
                 "choices": lanpaint_choices,
                 "default": 2,
@@ -41,8 +47,8 @@ class family_handler:
 
         if base_model_type in ["z_image_control", "z_image_control2", "z_image_control2_1"]:
             extra_model_def["mask_preprocessing"] = {
-                "selection":[ ""],
-                "visible": False
+                "selection": ["", "A", "NA"],
+                "visible": True,
             }
 
             extra_model_def["control_net_weight_name"] = "Control"
@@ -54,10 +60,6 @@ class family_handler:
             }
 
         if base_model_type in ["z_image_control2", "z_image_control2_1"]:
-            extra_model_def["mask_preprocessing"] = {
-                "selection":[ "", "A", "NA"],
-                "visible": False, 
-            }
             extra_model_def["parent_model_type"] = "z_image_control"
 
             # extra_model_def["image_ref_choices"] = {
@@ -191,6 +193,8 @@ class family_handler:
                     "NAG_scale": 1.0,
                     "NAG_tau": 3.5,
                     "NAG_alpha": 0.5,
+                    "denoising_strength": 1.0,
+                    "masking_strength": 0.25,
                 }
             )
 

--- a/models/z_image/z_image_handler.py
+++ b/models/z_image/z_image_handler.py
@@ -194,7 +194,7 @@ class family_handler:
                     "NAG_tau": 3.5,
                     "NAG_alpha": 0.5,
                     "denoising_strength": 1.0,
-                    "masking_strength": 0.25,
+                    "masking_strength": 1.0,
                 }
             )
 

--- a/models/z_image/z_image_handler.py
+++ b/models/z_image/z_image_handler.py
@@ -21,6 +21,24 @@ class family_handler:
         ]
         extra_model_def["text_encoder_folder"] = text_encoder_folder
 
+        lanpaint_choices = [
+            ("LanPaint (2 steps): ~2x slower, easy task", 2),
+            ("LanPaint (5 steps): ~5x slower, medium task", 3),
+            ("LanPaint (10 steps): ~10x slower, hard task", 4),
+            ("LanPaint (15 steps): ~15x slower, very hard task", 5),
+        ]
+
+        if base_model_type in ["z_image", "z_image_base", "z_image_control2", "z_image_control2_1"]:
+            extra_model_def["inpaint_support"] = True
+            extra_model_def["inpaint_video_prompt_type"] = "VA"
+            extra_model_def["image_video_prompt_type"] = ""
+            extra_model_def["model_modes"] = {
+                "choices": lanpaint_choices,
+                "default": 2,
+                "label": "Inpainting Method",
+                "image_modes": [2],
+            }
+
         if base_model_type in ["z_image_control", "z_image_control2", "z_image_control2_1"]:
             extra_model_def["mask_preprocessing"] = {
                 "selection":[ ""],
@@ -41,9 +59,6 @@ class family_handler:
                 "visible": False, 
             }
             extra_model_def["parent_model_type"] = "z_image_control"
-
-            extra_model_def["inpaint_support"] = True
-            extra_model_def["inpaint_video_prompt_type"]= "VA"
 
             # extra_model_def["image_ref_choices"] = {
             #     "choices":[("No Reference Image",""), ("Image is a Reference Image", "KI")],
@@ -186,3 +201,21 @@ class family_handler:
                         "control_net_weight":  0.75,
                     }
                 )
+
+    @staticmethod
+    def validate_generative_settings(base_model_type, model_def, inputs):
+        if base_model_type in ["z_image", "z_image_base", "z_image_control2", "z_image_control2_1"]:
+            model_mode = inputs.get("model_mode")
+            denoising_strength = inputs.get("denoising_strength", 1)
+            masking_strength = inputs.get("masking_strength", 1)
+            model_mode_int = None
+            if model_mode is not None:
+                try:
+                    model_mode_int = int(model_mode)
+                except (TypeError, ValueError):
+                    model_mode_int = None
+
+            if model_mode_int in (2, 3, 4, 5):
+                if denoising_strength != 1 or masking_strength != 1:
+                    import gradio as gr
+                    gr.Info("LanPaint forces Denoising Strength and Masking Strength to 1; non-1 values will be ignored.")

--- a/models/z_image/z_image_main.py
+++ b/models/z_image/z_image_main.py
@@ -190,6 +190,8 @@ class model_factory:
         NAG_alpha: float = 0.5,
         loras_slists=None,
         model_mode=None,
+        denoising_strength=1.0,
+        masking_strength=1.0,
         **kwargs,
     ):
         generator = torch.Generator(device="cuda" if torch.cuda.is_available() else "cpu")
@@ -254,6 +256,8 @@ class model_factory:
             loras_slists=loras_slists,
             model_mode_int=model_mode_int,
             lanpaint_enabled=lanpaint_enabled,
+            denoising_strength=denoising_strength,
+            masking_strength=masking_strength,
         )
 
         if images is None:

--- a/models/z_image/z_image_main.py
+++ b/models/z_image/z_image_main.py
@@ -189,6 +189,7 @@ class model_factory:
         NAG_tau: float = 3.5,
         NAG_alpha: float = 0.5,
         loras_slists=None,
+        model_mode=None,
         **kwargs,
     ):
         generator = torch.Generator(device="cuda" if torch.cuda.is_available() else "cpu")
@@ -217,6 +218,14 @@ class model_factory:
         if self.model_def.get("guidance_max_phases", 0) < 1:
             guide_scale = 0
 
+        model_mode_int = None
+        if model_mode is not None:
+            try:
+                model_mode_int = int(model_mode)
+            except (TypeError, ValueError):
+                model_mode_int = None
+        lanpaint_enabled = model_mode_int in (2, 3, 4, 5)
+
         images = self.pipeline(
             prompt=input_prompt,
             negative_prompt=n_prompt,
@@ -243,6 +252,8 @@ class model_factory:
             NAG_tau=NAG_tau,
             NAG_alpha=NAG_alpha,
             loras_slists=loras_slists,
+            model_mode_int=model_mode_int,
+            lanpaint_enabled=lanpaint_enabled,
         )
 
         if images is None:

--- a/shared/extra_settings.py
+++ b/shared/extra_settings.py
@@ -254,7 +254,11 @@ def _audio_scale_label(model_def: dict[str, Any] | None, _context: dict[str, Any
 
 
 def _guide_setting_visible(model_def: dict[str, Any]) -> bool:
-    return model_def.get("guide_custom_choices", None) is not None or model_def.get("guide_preprocessing", None) is not None
+    return (
+        model_def.get("guide_custom_choices", None) is not None
+        or model_def.get("guide_preprocessing", None) is not None
+        or bool(model_def.get("mask_strength_always_enabled", False))
+    )
 
 
 def _guidance_row_visible(model_def: dict[str, Any]) -> bool:


### PR DESCRIPTION
Enabled inpainting support via LanPaint.
<img width="1280" height="487" alt="Comparison-Z-Image" src="https://github.com/user-attachments/assets/014a7b72-8e25-432b-8680-469032e8b9f3" />
<img width="905" height="224" alt="image" src="https://github.com/user-attachments/assets/edb3fe85-7cb6-40aa-bd99-1c8b68cd8d44" />
Also enabled outpainting.