### PR TITLE
fix(mps): prevent Metal command buffer double-commit crash on 5B quanto models

### DIFF
--- a/shared/attention.py
+++ b/shared/attention.py
@@ -282,11 +282,11 @@ def pay_attention(
     final_padding = 0
     b, lq, lk = q.size(0), q.size(1), k.size(1)
 
-    q = q.to(v.dtype)
-    k = k.to(v.dtype)
+    q = q.to(v.dtype).contiguous()
+    k = k.to(v.dtype).contiguous()
     batch = len(q)
-    if len(k) != batch: k = k.expand(batch, -1, -1, -1)
-    if len(v) != batch: v = v.expand(batch, -1, -1, -1)
+    if len(k) != batch: k = k.expand(batch, -1, -1, -1).contiguous()
+    if len(v) != batch: v = v.expand(batch, -1, -1, -1).contiguous()
     if attn == "chipmunk":
         from src.chipmunk.modules import SparseDiffMlp, SparseDiffAttn
         from src.chipmunk.util import LayerCounter, GLOBAL_CONFIG

--- a/shared/mps/device_patch.py
+++ b/shared/mps/device_patch.py
@@ -338,9 +338,13 @@ if not hasattr(_torch.mps, 'set_device'):
 
 # Force SDPA math backend on MPS to avoid Metal command buffer double-commit crash
 # Reference: [IOGPUMetalCommandBuffer validate]:214: failed assertion `commit an already committed command buffer'
+# Root cause: Quando quantized models (5B mbf16) have ops that fallback to CPU,
+# corrupting MPS command buffers when mixed with native MPS SDPA.
+# Fix: synchronize MPS before SDPA to flush pending fallback ops.
 if _is_mps:
     _orig_sdpa = _torch.nn.functional.scaled_dot_product_attention
     def _patched_sdpa(*args, **kwargs):
+        _torch.mps.synchronize()
         with _torch.nn.attention.sdpa_kernel([_torch.nn.attention.SDPBackend.MATH]):
             return _orig_sdpa(*args, **kwargs)
     _torch.nn.functional.scaled_dot_product_attention = _patched_sdpa


### PR DESCRIPTION
## Root Cause

Wan 2.2 5B uses `quanto` mbf16 quantization. Quando ops lack native MPS kernels and fallback to CPU via `PYTORCH_ENABLE_MPS_FALLBACK=1`. These CPU fallback ops corrupt the MPS command buffer when mixed with native MPS SDPA attention.

The crash happens **immediately after first inference step** because the first quantized weight access + attention operation triggers the corruption.

## Why 14B works but 5B doesn't

- 14B uses standard safetensors weights -> all ops stay on MPS -> clean
- 5B uses `quanto` mbf16 -> weight access ops fallback to CPU -> buffer corruption

## Fix (2 changes)

1. **device_patch.py**: Add `torch.mps.synchronize()` before SDPA to flush pending fallback operations
2. **attention.py**: Add `.contiguous()` after `.to()` and `.expand()` to ensure tensor buffer independence

## Testing Needed

@SquishedSquirrel could you re-test Wan2.2 5B (with and without fastwan) on your M3 Max 36GB?

Ref: https://github.com/deepbeepmeep/Wan2GP/pull/1750#issuecomment-4388377997