### PR TITLE
fix(mps): skip quanto quantization on Apple Silicon

### DIFF
--- a/wgp.py
+++ b/wgp.py
@@ -2469,6 +2469,12 @@ def get_model_filename(model_type, quantization ="int8", dtype_policy = "", modu
         quantization = "bf16"
 
     dtype = get_transformer_dtype(model_type, dtype_policy)
+    # On Apple Silicon (MPS), skip quanto-quantized models to avoid
+    # CPU fallback crashes caused by Metal command buffer double-commit.
+    # MPS natively handles bf16/fp16, and 5B mbf16 fits easily in unified memory.
+    if sys.platform == 'darwin' and hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
+        if quantization in ("int8", "fp8"):
+            quantization = "bf16"
     if len(choices) <= 1:
         raw_filename = choices[0]
     else:
@@ -3424,6 +3430,9 @@ def load_models(model_type, override_profile = -1, output_type="video", **model_
         print(f"Unable to create a finetune quantized model as some modules are declared in the finetune definition. If your finetune includes already the module weights you can remove the 'modules' entry and try again. If not you will need also to change temporarly the model 'architecture' to an architecture that wont require the modules part ({modules}) to quantize and then add back the original 'modules' and 'architecture' entries.")
         save_quantized = False
     quantizeTransformer = not save_quantized and model_def !=None and transformer_quantization in ("int8", "fp8") and model_def.get("auto_quantize", False) and not "quanto" in model_filename
+    # MPS: disable quanto auto-quantization to avoid CPU fallback crashes
+    if sys.platform == 'darwin' and hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
+        quantizeTransformer = False
     if quantizeTransformer and len(modules) > 0:
         print(f"Autoquantize is not yet supported if some modules are declared")
         quantizeTransformer = False


### PR DESCRIPTION
## Problem

Wan2.2 5B (and potentially other models) crash on MPS with:
```
IOGPUMetalCommandBuffer validate:213: failed assertion "commit an already committed command buffer"
```

**Root cause**: `transformer_quantization` defaults to `"int8"`, causing `get_model_filename()` to select the `_quanto_mbf16_int8.safetensors` model file. Quanto quantized tensors lack MPS-native kernels → CPU fallback ops interleave with MPS-native SDPA → Metal command buffer corruption.

PR #1773 was a workaround (sync before SDPA + contiguous tensors). This PR is the **real fix**: don't use quanto on MPS at all.

## Solution

Two changes in `wgp.py`:

1. **`get_model_filename()`**: On Apple Silicon, force `quantization="bf16"` when it would be `"int8"`/`"fp8"`. This selects the non-quanto `_mbf16.safetensors` model file.

2. **`load_models()`**: Force `quantizeTransformer=False` on MPS to prevent auto-quantization of freshly loaded models.

## Resource Impact

- **5B mbf16**: ~10 GB (well within 36 GB unified memory)
- **14B mbf16**: ~28 GB (tight on 36 GB but works; for 14B users with Profile 3+ OOM, a future quantized MPS-kernel solution may still be needed)
- Quality identical to int8 version

## Testing

To test: run Wan2.2 5B on any Apple Silicon Mac. Should no longer crash on first inference step.