### PR TITLE
fix(mps): 3-layer defense against Metal command buffer crash (1.3B + 5B)

### DIFF
--- a/shared/attention.py
+++ b/shared/attention.py
@@ -282,11 +282,11 @@ def pay_attention(
     final_padding = 0
     b, lq, lk = q.size(0), q.size(1), k.size(1)
 
-    q = q.to(v.dtype)
-    k = k.to(v.dtype)
+    q = q.to(v.dtype).contiguous()
+    k = k.to(v.dtype).contiguous()
     batch = len(q)
-    if len(k) != batch: k = k.expand(batch, -1, -1, -1)
-    if len(v) != batch: v = v.expand(batch, -1, -1, -1)
+    if len(k) != batch: k = k.expand(batch, -1, -1, -1).contiguous()
+    if len(v) != batch: v = v.expand(batch, -1, -1, -1).contiguous()
     if attn == "chipmunk":
         from src.chipmunk.modules import SparseDiffMlp, SparseDiffAttn
         from src.chipmunk.util import LayerCounter, GLOBAL_CONFIG

--- a/shared/mps/device_patch.py
+++ b/shared/mps/device_patch.py
@@ -338,11 +338,58 @@ if not hasattr(_torch.mps, 'set_device'):
 
 # Force SDPA math backend on MPS to avoid Metal command buffer double-commit crash
 # Reference: [IOGPUMetalCommandBuffer validate]:214: failed assertion `commit an already committed command buffer'
+#
+# Root cause: MPS fallback ops (CPU fallback from PYTORCH_ENABLE_MPS_FALLBACK=1)
+# corrupt Metal command buffers when mixed with native MPS SDPA. This affects:
+#   - Wan 2.2 5B (quanto mbf16 quantization)
+#   - Wan 2.1 1.3B (standard safetensors, but ops still fallback)
+#   - Any model where CPU-fallback ops precede an SDPA call
+#
+# Fix strategy (defense in depth):
+#   1. Synchronize MPS before SDPA to flush pending fallback ops
+#   2. Force MATH backend (avoids MPS-native SDPA bugs on some macOS versions)
+#   3. If SDPA fails with Metal error, fall back to manual attention (matmul + softmax)
+#   4. Periodic empty_cache to prevent memory fragmentation
 if _is_mps:
     _orig_sdpa = _torch.nn.functional.scaled_dot_product_attention
+    _sdpa_call_count = [0]
+
+    def _manual_sdpa_fallback(query, key, value, attn_mask=None, is_causal=False, scale=None):
+        """Manual attention fallback: matmul + softmax, no Metal SDPA."""
+        # query: (B, H, L, D) or (B, L, H, D) after sdpa_kernel wrap
+        L = query.size(-2)
+        D = query.size(-1)
+        if scale is None:
+            scale = D ** -0.5
+
+        attn_weights = _torch.matmul(query, key.transpose(-2, -1)) * scale
+        if attn_mask is not None:
+            attn_weights = attn_weights + attn_mask
+        if is_causal:
+            causal_mask = _torch.triu(
+                _torch.ones(L, L, device=query.device, dtype=_torch.bool), diagonal=1
+            )
+            attn_weights = attn_weights.masked_fill(causal_mask, float('-inf'))
+        attn_weights = _torch.nn.functional.softmax(attn_weights, dim=-1)
+        return _torch.matmul(attn_weights, value)
+
     def _patched_sdpa(*args, **kwargs):
-        with _torch.nn.attention.sdpa_kernel([_torch.nn.attention.SDPBackend.MATH]):
-            return _orig_sdpa(*args, **kwargs)
+        # Flush pending MPS fallback ops before SDPA
+        _torch.mps.synchronize()
+
+        # Periodic cache cleanup every 256 SDPA calls
+        _sdpa_call_count[0] += 1
+        if _sdpa_call_count[0] % 256 == 0:
+            _torch.mps.empty_cache()
+
+        try:
+            with _torch.nn.attention.sdpa_kernel([_torch.nn.attention.SDPBackend.MATH]):
+                return _orig_sdpa(*args, **kwargs)
+        except Exception:
+            # Metal command buffer corruption caught — fall back to manual attention
+            # This handles cases where synchronize isn't sufficient (e.g. macOS 26.x bugs)
+            return _manual_sdpa_fallback(*args, **kwargs)
+
     _torch.nn.functional.scaled_dot_product_attention = _patched_sdpa
 
 if _is_mps:


### PR DESCRIPTION
## Problem

@SquishedSquirrel found that Wan 2.1 **1.3B** crashes on M3 Max 36GB with:
```
[IOGPUMetalCommandBuffer validate]:213: failed assertion commit an already committed command buffer
```
This happens on **all memory profiles** (3, 3+, 4, 5) — while 14B Lightning works fine.

## Root Cause

The existing fix (forcing SDPA MATH backend) was not enough. MPS fallback ops (CPU fallback from `PYTORCH_ENABLE_MPS_FALLBACK=1`) corrupt Metal command buffers when mixed with native MPS SDPA attention. This affects:
- Wan 2.1 1.3B (standard safetensors — fallback ops from layer norm, activations)
- Wan 2.2 5B (quanto mbf16 quantization)

## Fix: 3-Layer Defense

1. **torch.mps.synchronize()** before every SDPA call — flushes pending fallback ops
2. **.contiguous()** after .to() and .expand() in attention.py — tensor buffer isolation
3. **try/except + manual fallback** (matmul+softmax) if SDPA fails — catches macOS 26.x Metal bugs

Plus periodic empty_cache every 256 SDPA calls to prevent memory fragmentation.

## Testing Needed

@SquishedSquirrel @cn0ss — please re-test on your Macs:
- [ ] Wan 2.1 1.3B on M3/M4 Max
- [ ] Wan 2.2 5B (with and without fastwan)
- [ ] Verify 14B still works

Supersedes: #1773 (absorbs its fixes + adds fallback)