### PR TITLE
fix(mps): native MPS dequant+matmul for quanto int8 weights (replaces #1775)

### DIFF
--- a/shared/kernels/quanto_int8_inject.py
+++ b/shared/kernels/quanto_int8_inject.py
@@ -208,11 +208,25 @@ def _add_bias_in_place_or_fallback(output: torch.Tensor, bias: Optional[torch.Te
 def _default_quanto_qbytes_linear_forward(ctx, input, other, bias=None):
     ctx.save_for_backward(input, other)
     if _is_qbytes_tensor(input):
+        # MPS: torch.ops.quanto.qbytes_mm has no MPS kernel → CPU fallback
+        # → CPU/MPS op interleaving corrupts Metal command buffer.
+        # Use native MPS dequant+matmul instead.
+        if input.device.type == "mps":
+            act = input._data.to(input._scale.dtype) * input._scale
+            wgt = other._data.to(input._scale.dtype) * other._scale
+            output = act @ wgt.t()
+            return _add_bias_in_place_or_fallback(output, bias)
         output = torch.ops.quanto.qbytes_mm(input._data, other._data, input._scale * other._scale)
     else:
         in_features = input.shape[-1]
         out_features = other.shape[0]
         output_shape = input.shape[:-1] + (out_features,)
+        # MPS: same reason — qbytes_mm falls back to CPU on MPS.
+        if input.device.type == "mps":
+            wgt = other._data.to(input.dtype) * other._scale
+            output = input.reshape(-1, in_features) @ wgt.t()
+            output = output.reshape(output_shape)
+            return _add_bias_in_place_or_fallback(output, bias)
         output = torch.ops.quanto.qbytes_mm(input.reshape(-1, in_features), other._data, other._scale)
         output = output.reshape(output_shape)
     return _add_bias_in_place_or_fallback(output, bias)


### PR DESCRIPTION
## Problem

`torch.ops.quanto.qbytes_mm()` has no MPS kernel implementation. On Apple Silicon this causes CPU fallback ops that interleave with MPS-native SDPA attention ops, corrupting the Metal command buffer and causing crash on Wan 2.2 5B and Wan 2.1 1.3B.

## Root Cause

`torch.ops.quanto.qbytes_mm` only has CUDA and CPU implementations. When called with MPS tensors, PyTorch dispatches to CPU fallback. CPU ops scheduled on Metal command buffer alongside native MPS ops → double-commit assertion failure.

## Fix

When device is `mps`, use native PyTorch operations to manually dequantize int8 weights and perform matrix multiplication. All ops (`.to()`, `*`, `@`) have native MPS kernels → zero CPU fallback.

## Benefits over #1775 (skip-quanto)

| | #1775 (skip) | This PR (fix) |
|---|---|---|
| Memory | ~10GB (bf16 weights) | ~5GB (int8 weights) |
| Download | bf16 file always | int8 file (half size) |
| Quality | identical | identical |
| Owner feedback | rejected | addresses feedback |

@SquishedSquirrel @cn0ss would appreciate testing on M3 Max / M4 Max!

Closes #1775
