### PR TITLE
Fix: webui-queue task can hang forever when never admitted (no admission timeout)

### DIFF
--- a/shared/api_webui.py
+++ b/shared/api_webui.py
@@ -213,6 +213,7 @@ class WebUIQueueProbe:
     _POLL_INTERVAL_SECONDS = 0.2
     _MISSING_OUTPUT_TIMEOUT_SECONDS = 5.0
     _QUEUE_ADMISSION_SUSPEND_NOTICE_SECONDS = 10.0
+    _QUEUE_ADMISSION_TIMEOUT_SECONDS = 120.0
     _INLINE_QUEUE_SLOT_TIMEOUT_SECONDS = 10.0
     _CANCEL_GRACE_SECONDS = 1.0
 
@@ -543,7 +544,28 @@ class WebUIQueueProbe:
         if self._gen.get("in_progress", False) or list(self._gen.get("queue", []) or []):
             self._submitted_at = time.time()
             return
-        if self._submitted_at <= 0 or time.time() - self._submitted_at < self._QUEUE_ADMISSION_SUSPEND_NOTICE_SECONDS or self._queue_wait_suspended:
+        if self._submitted_at <= 0:
+            return
+        waited = time.time() - self._submitted_at
+        if waited >= self._QUEUE_ADMISSION_TIMEOUT_SECONDS:
+            # The load_queue trigger round-trip never completed (e.g. the Media
+            # Generator tab/window lost browser focus and the browser throttled the
+            # socket), so the task was never admitted to the queue. No other code path
+            # errors an un-admitted task -- the missing-output timeout is gated behind
+            # admission -- so without this, run() loops forever and SessionJob.result()
+            # blocks its caller permanently with no output and no error. Fail the
+            # still-pending clients so run() can return with an actionable error.
+            print(f"WanGP API queue admission timed out after {waited:.0f}s client_ids={pending_client_ids}")
+            for client_id in pending_client_ids:
+                self._register_error(
+                    client_id,
+                    "WanGP never started this generation: the queue never admitted the "
+                    "task (the Media Generator likely lost browser focus). Give the "
+                    "Media Generator tab focus and try again.",
+                    stage="admission",
+                )
+            return
+        if waited < self._QUEUE_ADMISSION_SUSPEND_NOTICE_SECONDS or self._queue_wait_suspended:
             return
         print("WanGP API queue suspended while waiting for Media Generator to get browser focus")
         self._publish("status", "Waiting for WanGP Media Generator to get browser focus...", "on_status")


### PR DESCRIPTION
### Problem

A task submitted via the webui queue (`SessionJob` → `submit_task().result()`) can block its caller **forever, with no error**, if it is never admitted to the queue.

This happens when the `load_queue_trigger` round-trip to the browser doesn't complete — e.g. the Media Generator tab/window is backgrounded and the browser throttles the socket. The task is never picked up by `process_tasks`, and nothing ever times out:

- `WebUIQueueProbe.run()` (`shared/api_webui.py`) polls with **no overall/admission deadline**.
- The only pre-admission path, `_check_queue_admission_timeout`, just publishes a "waiting for focus" status — it **never registers an error or breaks**.
- The 5s missing-output timeout is gated behind admission (`if client_id not in self._admitted_client_ids: continue`), so it can't fire for an un-admitted task.
- `job._set_result()` only runs after `run()` returns, so `SessionJob.result(timeout=None)` (`shared/api.py`) blocks the caller permanently.

Net result: the caller hangs indefinitely with no output and no error. It's easy to hit from API/plugin callers that submit a generation and then `.result()`.

### Fix

Add a bounded admission deadline (`_QUEUE_ADMISSION_TIMEOUT_SECONDS`, 120s). In `_check_queue_admission_timeout`, once a task stays un-admitted past the cap while the main queue is genuinely idle, `_register_error(..., stage="admission")` the still-pending clients.

Since `_all_clients_finished()` counts errors, `run()` then returns, `_set_result` fires, and `.result()` unblocks with an actionable message instead of hanging.

### Impact

- No behavior change for normal runs — the timer only advances during true admission stalls (no `in_progress`, empty queue), and the existing 10s "waiting for focus" notice is unchanged.
- Turns an unrecoverable silent hang into a clear, retryable error for any webui-queue caller.
