### PR TITLE
Fix API silently ignoring image_guide/image_mask passed as file paths

### DIFF
--- a/shared/api.py
+++ b/shared/api.py
@@ -1007,6 +1007,12 @@ class WanGPSession:
             return path.resolve()
         return (caller_base_path / path).resolve()
 
+    # wgp.py loads image_refs/image_start/image_end from path strings, but it only
+    # honors image_guide/image_mask when they are ALREADY PIL Images. On the API
+    # path these arrive as path strings, so the control image / mask gets silently
+    # dropped. Load them here to match the Gradio UI behaviour.
+    _IMAGE_LOAD_KEYS = ("image_guide", "image_mask")
+
     def _absolutize_task_paths(self, task: dict[str, Any], caller_base_path: Path) -> dict[str, Any]:
         normalized = copy.deepcopy(task)
         settings = normalized.get("params")
@@ -1016,7 +1022,26 @@ class WanGPSession:
             if key not in settings:
                 continue
             settings[key] = self._absolutize_setting_path(settings[key], caller_base_path)
+            if key in self._IMAGE_LOAD_KEYS:
+                settings[key] = self._load_image_attachment(settings[key])
         return normalized
+
+    def _load_image_attachment(self, value: Any) -> Any:
+        if value is None or isinstance(value, Image.Image):
+            return value
+        if isinstance(value, list):
+            return [self._load_image_attachment(item) for item in value]
+        if isinstance(value, os.PathLike):
+            value = os.fspath(value)
+        if not isinstance(value, str) or not value.strip():
+            return value
+        if parse_virtual_media_path(value) is not None:
+            return value
+        module = self._ensure_runtime().module
+        img = module._open_image_input(value)
+        if img is None:
+            raise ValueError(f"image attachment could not be opened: {value!r}")
+        return module.convert_image(img)
 
     def _get_attachment_keys(self) -> tuple[str, ...]:
         if self._attachment_keys is None:


### PR DESCRIPTION
### Problem

When submitting a generation through the programmatic API (`shared/api.py`), setting `image_guide` (or `image_mask`) to a file path has no effect on the output. The same seed + prompt with and without `image_guide` produce pixel-identical images, and no error is raised. This makes it impossible to drive ControlNet-style runs (e.g. `z_image_control`) from the API.

### Root cause

On the API submission path, `_absolutize_task_paths` only absolutizes the attachment path strings — it never opens them. `wgp.py` does load `image_refs`, `image_start` and `image_end` from path strings (via `clean_image_list` → `_open_image_input`), but `image_guide`/`image_mask` are only honored when they are already `PIL.Image` objects:

```python
if image_guide is not None and isinstance(image_guide, Image.Image):
    video_guide = image_guide; image_guide = None
```

From the Gradio UI these arrive as PIL images, so it works there. From the API they arrive as strings, fail the `isinstance` check, and get silently dropped — so the ControlNet `context_scale` is never set and the control image contributes nothing. No error, no effect.

### Fix

After absolutizing paths, load `image_guide`/`image_mask` into PIL images, reusing wgp.py's own `_open_image_input` / `convert_image` helpers so colour and EXIF handling match the UI exactly. Specifics:

- Only `image_guide`/`image_mask` are loaded. `video_*` and `audio_*` keys stay as path strings, since they are consumed as files downstream.
- `image_start`/`image_end`/`image_refs` are left untouched — wgp.py already loads those.
- Already-PIL values and virtual-media specs are passed through unchanged.
- An unopenable path now raises a clear `ValueError` instead of being silently dropped.

The change is confined to `shared/api.py` and does not touch the Gradio entry point.

### How to verify

Pick a control model (e.g. `z_image_control`) and generate twice at the same seed + prompt — once with `image_guide` set to a photo and `video_prompt_type` containing `VD`, once with no guide. Before this change the two outputs are pixel-identical; after it they differ, and the job log shows the preprocessing step (e.g. "Extracting Depth Map").
