### PR TITLE
Fix compilation error for LongCat on 5070ti

### DIFF
--- a/shared/kernels/quanto_int8_triton.py
+++ b/shared/kernels/quanto_int8_triton.py
@@ -83,7 +83,7 @@ _TRITON_LARGE_M_SHAPE_CONFIGS = {
     (4096, 3840): (64, 256, 64, 8, 4),
     (15360, 3840): (64, 256, 64, 8, 4),
     # Hot WAN2 I2V enhanced-lightning fused-int8 shapes (M ~= 512).
-    (4096, 4096): (64, 256, 64, 8, 4),
+    (4096, 4096): (64, 256, 64, 8, 3),
     (4096, 10240): (64, 256, 64, 8, 4),
     (10240, 4096): (64, 256, 64, 8, 4),
 }
@@ -198,7 +198,7 @@ def _select_static_triton_int8_config(m: int, k: int, n: int) -> tuple[int, int,
         if cfg is not None:
             return cfg
         if n >= 2048:
-            return (64, 256, 64, 8, 4)
+            return (64, 256, 64, 8, 3)
     return _TRITON_LARGE_M_DEFAULT
 
 


### PR DESCRIPTION
It was giving me an error: `triton.runtime.errors.OutOfResources: out of resource: shared memory, Required: 102400, Hardware limit: 101376, reduce block size or num_stages`.

Compilation gives me almost twice as much speed for this model, so it's a must have especially in the absence of accelerator loras. You need to clear the .triton\autotune folder to have effect.

I'm new to this stuff so I can't predict how it would affect the performance of other models, but I tested that at least it doesn't cause errors when using them. Perhaps there exists a better combination of numbers that would get closer to the limit without going overboard?

Searching for this issue also gave me these results and some others mentioning the same limit:
 https://github.com/NVIDIA/cutlass/issues/3144
 https://github.com/vllm-project/vllm/issues/46721 
maybe this would give you a better insight.