### PR TITLE
Fix get_model_schema JSON-serialization crash on LTX-2 2.3 and SCAIL-2

### DIFF
--- a/shared/api.py
+++ b/shared/api.py
@@ -546,7 +546,7 @@ class WanGPSession:
             return None
         metadata = copy.deepcopy(model_def.get("metadata", {}))
         metadata.setdefault("model_type", str(model_type))
-        return {
+        result = {
             "model_type": str(model_type),
             "name": model_def.get("name", str(model_type)),
             "model_def": model_def,
@@ -554,6 +554,7 @@ class WanGPSession:
             "setting_values": copy.deepcopy(metadata.get("setting_values", {})),
             "default_settings": self.get_default_settings(model_type),
         }
+        return _json_safe(result)
 
     def submit(self, source: str | os.PathLike[str] | dict[str, Any] | list[dict[str, Any]], callbacks: object | None = None) -> SessionJob:
         tasks = self._normalize_source(source, caller_base_path=self._get_caller_base_path())
@@ -1232,6 +1233,22 @@ def _apply_edit_settings_overrides(settings: dict[str, Any], settings_overrides:
         options["return_media"] = True
     if options:
         settings["_api"] = options
+
+
+def _json_safe(obj: Any) -> Any:
+    """Recursively strip non-JSON-serializable values (e.g. callables injected into
+    model_def by handlers) so a schema response can be JSON-encoded by the MCP layer.
+
+    Callable keys are dropped entirely: they are runtime-only generation hooks and
+    carry no descriptive value for schema clients. The live model_def used during
+    generation is unaffected because get_model_def returns a deepcopy."""
+    if callable(obj):
+        return None
+    if isinstance(obj, dict):
+        return {k: _json_safe(v) for k, v in obj.items() if not callable(v)}
+    if isinstance(obj, (list, tuple)):
+        return [_json_safe(v) for v in obj if not callable(v)]
+    return obj
 
 
 def _model_availability_to_dict(model_type: str, status: int) -> dict[str, Any]:


### PR DESCRIPTION
## Problem
`wangp_get_model_schema` raises `Unable to serialize unknown type: <class ''function''>` for LTX-2 22B (`ltx2_22B*`) and SCAIL-2 (`scail2_14B`, `scail2_1.3B`) models. Their `model_def`s embed Python function objects injected at runtime by the handlers (`guide_inpaint_color`, `background_removal_color`, `preprocess_all`, `custom_image_ref_postprocessor`), which the MCP layer can''t JSON-encode.

## Fix
Add a recursive `_json_safe` sanitizer in `shared/api.py` that strips callables from the schema response. Generation is unaffected — `get_model_def` returns a deepcopy, so the live `model_def` keeps its callables.

## Testing
`json.dumps(session.get_model_schema(mt))` now succeeds for `ltx2_19B`, `ltx2_22B`, `ltx2_22B_1_1`, `ltx2_22B_distilled_1_1`, `scail2_14B`, `scail2_1.3B`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)