### PR TITLE
Fix LTX Video skip_layer_mask device mismatch under mmgp offloading

### DIFF
--- a/models/ltx_video/models/transformers/attention.py
+++ b/models/ltx_video/models/transformers/attention.py
@@ -350,7 +350,7 @@ class BasicTransformerBlock(nn.Module):
             skip_layer_mask is not None
             and skip_layer_strategy == SkipLayerStrategy.TransformerBlock
         ):
-            skip_layer_mask = skip_layer_mask.view(-1, 1, 1)
+            skip_layer_mask = skip_layer_mask.view(-1, 1, 1).to(hidden_states.device)
             hidden_states = hidden_states * skip_layer_mask + original_hidden_states * (
                 1.0 - skip_layer_mask
             )
@@ -1014,7 +1014,11 @@ class AttnProcessor2_0:
         )
 
         if skip_layer_mask is not None:
-            skip_layer_mask = skip_layer_mask.reshape(batch_size, 1, 1)
+            # The mask is created on the transformer's device, which is cpu when
+            # mmgp offloading is active, so follow the activations' device here.
+            skip_layer_mask = skip_layer_mask.reshape(batch_size, 1, 1).to(
+                hidden_states.device
+            )
 
         if (attention_mask is not None) and (not attn.use_tpu_flash_attention):
             attention_mask = attn.prepare_attention_mask(


### PR DESCRIPTION
## What

Moves `skip_layer_mask` to the activations' device at its consumption points in `models/ltx_video/models/transformers/attention.py`:

- in `AttnProcessor2_0.__call__`, at the `reshape(batch_size, 1, 1)` step — covers the `AttentionSkip`, `AttentionValues`, and `Residual` strategies downstream;
- in `BasicTransformerBlock.forward`, at the `view(-1, 1, 1)` step — covers the `TransformerBlock` strategy.

## Why

`Transformer3DModel.create_skip_layer_mask` builds the mask with `device=self.device`. Under mmgp offloading the transformer's parameters live in CPU RAM between calls, so `self.device` reports `cpu` and the mask is created there, while activations run on cuda. Any STG generation that actually skips blocks (an all-ones mask is discarded early) crashes with:

```
File ".../models/ltx_video/models/transformers/attention.py", line 1132, in __call__
  hidden_states_a *= skip_layer_mask
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

Reproduced with LTX Video 0.9.8 13B (`ltxv_0.9.8_13B_dev_quanto_bf16_int8.safetensors`) on Windows, torch 2.10.0+cu130, mmgp 3.7.6. Fixing at the consumption points (rather than at mask creation) keeps the fix correct wherever mmgp happens to be keeping the weights at the time.

## Notes for review

- #1822 patches the same crash but only the `AttentionSkip` and `AttentionValues` branches, bundled with unrelated AMD/ROCm changes. This PR is the standalone, complete version: the `Residual` and `TransformerBlock` branches have the identical latent bug and are covered here.
- The `.to()` is a no-op when the mask is already on the right device, so non-offloaded setups are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)