### PR TITLE
Fix LTX2 prompt relay frame quantization

### DIFF
--- a/shared/prompt_relay.py
+++ b/shared/prompt_relay.py
@@ -117,7 +117,7 @@ class PromptRelayMaskBuilder:
 
         raw_query_frames = frame_indices.to(torch.float32)
         raw_max_frame = raw_query_frames.amax(dim=1, keepdim=True).clamp_min(1.0)
-        visible_start = raw_max_frame * self.visible_start_ratio
+        visible_start = torch.round(raw_max_frame * self.visible_start_ratio)
         query_frames = raw_query_frames - visible_start
         max_frame = (raw_max_frame - visible_start).clamp_min(1.0)
         sigma_sq = 2.0 * self.sigma * self.sigma
@@ -126,11 +126,11 @@ class PromptRelayMaskBuilder:
             end_key = min(segment.key_end, positive_len)
             if start_key >= end_key:
                 continue
-            start = torch.tensor(segment.start, device=device, dtype=torch.float32) * max_frame
-            end = torch.tensor(segment.end, device=device, dtype=torch.float32) * max_frame
+            start = torch.round(torch.tensor(segment.start, device=device, dtype=torch.float32) * max_frame)
+            end = torch.round(torch.tensor(segment.end, device=device, dtype=torch.float32) * max_frame)
             length = (end - start).clamp_min(1.0)
-            midpoint = (start + end) * 0.5
-            window = (length * 0.5 - 2.0).clamp_min(0.0)
+            midpoint = torch.floor((start + end) * 0.5)
+            window = (torch.floor(length * 0.5) - 2.0).clamp_min(0.0)
             distance = (query_frames - midpoint).abs()
             cost = torch.relu(distance - window).square() / sigma_sq
             mask[:, :, start_key:end_key] = -cost.unsqueeze(-1)


### PR DESCRIPTION
## Summary

- Quantize prompt-relay visible offsets and segment bounds onto discrete latent query-frame indices.
- Use integral midpoint and full-strength window calculations after quantization.

## Why

Prompt-relay ranges are expressed as normalized positions, but attention masks are evaluated on discrete latent query frames. Fractional boundaries could land between those frames, causing short relay segments to miss their intended full-strength frame or behave inconsistently around boundaries.

## Impact

Short and narrow prompt-relay segments now map deterministically to actual latent frames. This only changes LTX2 prompt-relay mask construction; it adds no settings or API changes.

## Validation

- Compiled `shared/prompt_relay.py` with `py_compile`.
- Ran a focused five-frame mask assertion confirming a narrow relay segment retains a zero-cost, full-strength frame.
- Exercised the combined prompt-relay changes through AI Video Studio against WanGP 12.34.

This fix is independent from the companion configurable-epsilon feature.
