### PR TITLE
Expose LTX2 prompt relay epsilon

### DIFF
--- a/models/ltx2/ltx2.py
+++ b/models/ltx2/ltx2.py
@@ -1443,6 +1443,14 @@ class LTX2:
         if "1" in audio_prompt_type and effective_audio_cfg_scale <= 1.0:
             effective_audio_cfg_scale = LTX2_ID_LORA_AUDIO_CFG_SCALE
         sample_solver = sample_solver.lower()
+        prompt_relay_epsilon = 1e-3
+        if isinstance(custom_settings, dict):
+            try:
+                prompt_relay_epsilon = float(custom_settings.get("prompt_relay_epsilon", prompt_relay_epsilon))
+            except (TypeError, ValueError):
+                pass
+        if not 0 < prompt_relay_epsilon < 1:
+            prompt_relay_epsilon = 1e-3
         prompt_relay_frame_offset = 0
         if int(window_no or 1) > 1 or (input_video is not None and not is_start_image_only):
             prompt_relay_frame_offset = max(0, int(prefix_frames_count or 0))
@@ -1463,6 +1471,7 @@ class LTX2:
                 num_frames=int(frame_num),
                 frame_rate=float(fps),
                 prompt_relay_frame_offset=prompt_relay_frame_offset,
+                prompt_relay_epsilon=prompt_relay_epsilon,
                 num_inference_steps=int(sampling_steps),
                 cfg_guidance_scale=float(guide_scale),
                 audio_cfg_guidance_scale=effective_audio_cfg_scale,
@@ -1527,6 +1536,7 @@ class LTX2:
                 num_frames=int(frame_num),
                 frame_rate=float(fps),
                 prompt_relay_frame_offset=prompt_relay_frame_offset,
+                prompt_relay_epsilon=prompt_relay_epsilon,
                 images=images,
                 guiding_images=guiding_images or None,
                 guiding_images_stage2=guiding_images_stage2 or None,

--- a/models/ltx2/ltx2_handler.py
+++ b/models/ltx2/ltx2_handler.py
@@ -49,6 +49,16 @@ _EDITANYTHING_MODEL_DEF = {
     "ltx2_edit_anything_ref_token_scale": 0.25,
     "ltx2_edit_anything_adaln_scale": 2.0,
 }
+_PROMPT_RELAY_CUSTOM_SETTING = {
+    "id": "prompt_relay_epsilon",
+    "name": "Prompt Relay Epsilon",
+    "label": "Prompt Relay Epsilon (higher values create softer transitions)",
+    "type": "float",
+    "default": 1e-3,
+    "min": 1e-4,
+    "max": 0.99,
+    "inc": 1e-4,
+}
 _ARCH_SPECS = {
     "ltx2_19B": {
         "repo_id": "DeepBeepMeep/LTX-2",
@@ -426,6 +436,7 @@ class family_handler:
             "ltx2_hdr_scene_embeddings_file": spec.get("hdr_scene_embeddings", ""),
             "self_refiner": True,
             "self_refiner_max_plans": 2,
+            "custom_settings": [_PROMPT_RELAY_CUSTOM_SETTING.copy()],
             # "no_background_removal": True,
             "vae_block_size": 64,
             "keep_frames_video_guide_not_supported": True,
@@ -481,7 +492,10 @@ class family_handler:
                     "video_prompt_enhancer_max_tokens1": 1536,
                     "image_prompt_enhancer_max_tokens1": 1536,
                     "guide_custom_choices": {"choices": [("No Control Video Memory", ""), ("JoyAI-Echo Control Video Memory", "V1")], "letters_filter": "V1", "default": "", "label": "Control Video Memory"},
-                    "custom_settings": [{"id": JOYAI_CONTROL_MEMORY_SETTING, "name": "Control Video Memory Positions", "label": "Joy Memory Positions from Control Video (frames or seconds, comma-separated)", "type": "text", "default": "", "video_prompt_type": "1"}],
+                    "custom_settings": [
+                        _PROMPT_RELAY_CUSTOM_SETTING.copy(),
+                        {"id": JOYAI_CONTROL_MEMORY_SETTING, "name": "Control Video Memory Positions", "label": "Joy Memory Positions from Control Video (frames or seconds, comma-separated)", "type": "text", "default": "", "video_prompt_type": "1"},
+                    ],
                 }
             )
         else:

--- a/models/ltx2/ltx_pipelines/distilled.py
+++ b/models/ltx2/ltx_pipelines/distilled.py
@@ -214,6 +214,7 @@ class DistilledPipeline:
         frame_rate: float,
         images: list[tuple[str, int, float]],
         prompt_relay_frame_offset: int = 0,
+        prompt_relay_epsilon: float = 1e-3,
         negative_prompt: str = DEFAULT_NEGATIVE_PROMPT,
         guiding_images: list[tuple] | None = None,
         guiding_images_stage2: list[tuple] | None = None,
@@ -335,7 +336,7 @@ class DistilledPipeline:
                 audio_connector,
                 return_attention_masks=True,
             )
-            relay_conditioning = encode_prompt_relay(prompt, encode_fn_with_masks, self.text_encoder_cache, self.device, num_frames, frame_rate, text_encoder.tokenizer, visible_frame_offset=prompt_relay_frame_offset)
+            relay_conditioning = encode_prompt_relay(prompt, encode_fn_with_masks, self.text_encoder_cache, self.device, num_frames, frame_rate, text_encoder.tokenizer, visible_frame_offset=prompt_relay_frame_offset, epsilon=prompt_relay_epsilon)
             if relay_conditioning is not None:
                 video_context = relay_conditioning.video_context
                 audio_context = None if skip_audio else relay_conditioning.audio_context

--- a/models/ltx2/ltx_pipelines/ti2vid_one_stage.py
+++ b/models/ltx2/ltx_pipelines/ti2vid_one_stage.py
@@ -83,6 +83,7 @@ class TI2VidOneStagePipeline:
         cfg_guidance_scale: float,
         images: list[tuple[str, int, float]],
         prompt_relay_frame_offset: int = 0,
+        prompt_relay_epsilon: float = 1e-3,
         audio_cfg_guidance_scale: float | None = None,
         cfg_star_switch: int = 0,
         apg_switch: int = 0,
@@ -163,7 +164,7 @@ class TI2VidOneStagePipeline:
             audio_connector,
             return_attention_masks=True,
         )
-        relay_conditioning = encode_prompt_relay(prompt, encode_fn_with_masks, self.text_encoder_cache, self.device, num_frames, frame_rate, text_encoder.tokenizer, visible_frame_offset=prompt_relay_frame_offset)
+        relay_conditioning = encode_prompt_relay(prompt, encode_fn_with_masks, self.text_encoder_cache, self.device, num_frames, frame_rate, text_encoder.tokenizer, visible_frame_offset=prompt_relay_frame_offset, epsilon=prompt_relay_epsilon)
         if relay_conditioning is None:
             contexts = self.text_encoder_cache.encode(
                 encode_fn,

--- a/models/ltx2/ltx_pipelines/ti2vid_two_stages.py
+++ b/models/ltx2/ltx_pipelines/ti2vid_two_stages.py
@@ -138,6 +138,7 @@ class TI2VidTwoStagesPipeline:
         cfg_guidance_scale: float,
         images: list[tuple[str, int, float]],
         prompt_relay_frame_offset: int = 0,
+        prompt_relay_epsilon: float = 1e-3,
         audio_cfg_guidance_scale: float | None = None,
         cfg_star_switch: int = 0,
         apg_switch: int = 0,
@@ -262,7 +263,7 @@ class TI2VidTwoStagesPipeline:
             audio_connector,
             return_attention_masks=True,
         )
-        relay_conditioning = encode_prompt_relay(prompt, encode_fn_with_masks, self.text_encoder_cache, self.device, num_frames, frame_rate, text_encoder.tokenizer, visible_frame_offset=prompt_relay_frame_offset)
+        relay_conditioning = encode_prompt_relay(prompt, encode_fn_with_masks, self.text_encoder_cache, self.device, num_frames, frame_rate, text_encoder.tokenizer, visible_frame_offset=prompt_relay_frame_offset, epsilon=prompt_relay_epsilon)
         if relay_conditioning is None:
             contexts = self.text_encoder_cache.encode(
                 encode_fn,

--- a/shared/prompt_relay.py
+++ b/shared/prompt_relay.py
@@ -177,6 +177,7 @@ def encode_prompt_relay(
     frame_rate: float,
     tokenizer: Any,
     visible_frame_offset: int = 0,
+    epsilon: float = 1e-3,
 ) -> PromptRelayConditioning | None:
     plan = parse_prompt_relay(prompt)
     if plan is None:
@@ -193,8 +194,8 @@ def encode_prompt_relay(
     return PromptRelayConditioning(
         video_context=video_context,
         audio_context=audio_context,
-        video_mask_builder=_build_mask_builder(plan, video_context, video_mask, token_ranges, num_frames, frame_rate, visible_frame_offset),
-        audio_mask_builder=None if audio_context is None else _build_mask_builder(plan, audio_context, audio_mask, token_ranges, num_frames, frame_rate, visible_frame_offset),
+        video_mask_builder=_build_mask_builder(plan, video_context, video_mask, token_ranges, num_frames, frame_rate, visible_frame_offset, epsilon),
+        audio_mask_builder=None if audio_context is None else _build_mask_builder(plan, audio_context, audio_mask, token_ranges, num_frames, frame_rate, visible_frame_offset, epsilon),
     )
 
 
@@ -206,6 +207,7 @@ def _build_mask_builder(
     num_frames: int,
     frame_rate: float,
     visible_frame_offset: int = 0,
+    epsilon: float = 1e-3,
 ) -> PromptRelayMaskBuilder | None:
     runtime_segments = []
     num_frames = max(int(num_frames), 1)
@@ -225,7 +227,7 @@ def _build_mask_builder(
         runtime_segments.append(_RuntimeSegment(start, end, start_key, end_key))
     if not any(segment.start > 0.0 or segment.end < 1.0 for segment in runtime_segments):
         return None
-    return PromptRelayMaskBuilder(_normalize_key_mask(mask, seq_len), runtime_segments, seq_len, visible_start_ratio=visible_start_ratio)
+    return PromptRelayMaskBuilder(_normalize_key_mask(mask, seq_len), runtime_segments, seq_len, visible_start_ratio=visible_start_ratio, epsilon=epsilon)
 
 
 def _parse_marker(marker: str) -> tuple[PromptRelayBound, PromptRelayBound | None] | None:


### PR DESCRIPTION
## Summary

- Expose Prompt Relay Epsilon as an LTX2 custom setting.
- Validate the value and fall back to the existing `1e-3` default when invalid.
- Pass the setting through distilled, one-stage, and two-stage LTX2 pipelines.

## Why

Prompt-relay epsilon controls the attention-mask falloff around each segment. The previous fixed `1e-3` value gives one transition profile, but different prompts and segment lengths can benefit from sharper or softer transitions.

Making epsilon editable allows users to tune that falloff without modifying source code. Higher values produce a wider, softer transition; lower values produce a tighter transition.

## Impact

Existing projects retain identical behavior because the default remains `1e-3`. Values must satisfy `0 < epsilon < 1`; invalid values safely use the default. The setting is available across the supported LTX2 pipeline variants, including configurations that also expose JoyAI control-memory settings.

## Validation

- Compiled all six changed Python files with `py_compile`.
- Verified the default sigma remains derived from `1e-3` and a custom epsilon changes it.
- Exercised editable epsilon through AI Video Studio against WanGP 12.34.

Companion frame-quantization fix: #2018. The two patches are independent and may merge in either order.
