### PR TITLE
Krea 2: auto-convert diffusers-format LoRA keys to native naming (#1994)

### DIFF
--- a/models/krea2/krea2_mmdit.py
+++ b/models/krea2/krea2_mmdit.py
@@ -454,6 +454,11 @@ class SingleStreamDiT(nn.Module):
         self.last = LastLayer(config.features, config.patch, config.channels)
         self.tproj = nn.Sequential(nn.GELU(approximate="tanh"), nn.Linear(config.features, config.features * 6))
 
+    def preprocess_loras(self, model_type, sd):
+        from .lora_convert import convert_diffusers_lora
+
+        return convert_diffusers_lora(sd)
+
     def prepare_context(self, context: Tensor | list[Tensor], mask: Tensor, output_len: int | None = None) -> Tensor | None:
         self.txtfusion._interrupt = getattr(self, "_interrupt", False)
         if isinstance(context, list):

--- a/models/krea2/lora_convert.py
+++ b/models/krea2/lora_convert.py
@@ -1,0 +1,63 @@
+"""Convert diffusers-port Krea 2 LoRA key naming to WanGP's native naming.
+
+The diffusers port of Krea 2 renames every module (transformer_blocks/attn.to_q
+style); LoRAs trained against it (a sizable share of Civitai's Krea 2 catalog)
+fail to load in WanGP with "unexpected module keys"
+(https://github.com/deepbeepmeep/Wan2GP/issues/1994). The mapping is 1:1 —
+both implementations use unfused attention and the same SwiGLU layout — so a
+pure key rename suffices; tensors are untouched.
+
+Runs inside mmgp's preprocess_sd hook, i.e. BEFORE mmgp strips the
+"transformer."/"diffusion_model." prefix — rules therefore keep any prefix
+intact and are anchored on interior segments. Suffix-agnostic: the same rules
+cover .lora_A/.lora_B/.lora_down/.lora_up/.alpha/.dora_scale keys.
+
+Torch-free on purpose so it can be unit-tested standalone.
+"""
+
+# Markers that only ever appear in the diffusers-port naming.
+_DIFFUSERS_MARKERS = ("transformer_blocks.", "text_fusion.", ".attn.to_q.")
+
+# Ordered rules; each is (search, replace) on the full key string.
+# ".attn.to_out.0." must precede the other attn renames only for clarity —
+# none of the patterns overlap, but keep the compound one first anyway.
+_RENAME_RULES = (
+    (".attn.to_out.0.", ".attn.wo."),
+    (".attn.to_q.", ".attn.wq."),
+    (".attn.to_k.", ".attn.wk."),
+    (".attn.to_v.", ".attn.wv."),
+    (".attn.to_gate.", ".attn.gate."),
+    (".ff.", ".mlp."),                      # SwiGLU field names (up/gate/down) already match
+    ("text_fusion.", "txtfusion."),
+    ("transformer_blocks.", "blocks."),     # safe: the "transformer." *prefix* ends with "." before "transformer_blocks"
+    ("time_embed.linear_1.", "tmlp.0."),    # nn.Sequential(Linear, GELU, Linear)
+    ("time_embed.linear_2.", "tmlp.2."),
+    ("time_mod_proj.", "tproj.1."),         # nn.Sequential(GELU, Linear)
+    ("txt_in.linear_1.", "txtmlp.1."),      # nn.Sequential(RMSNorm, Linear, GELU, Linear)
+    ("txt_in.linear_2.", "txtmlp.3."),
+    ("final_layer.linear.", "last.linear."),
+    ("img_in.", "first."),
+)
+
+
+def is_diffusers_lora(state_dict):
+    for key in state_dict:
+        for marker in _DIFFUSERS_MARKERS:
+            if marker in key:
+                return True
+    return False
+
+
+def convert_diffusers_lora(state_dict):
+    """Return a converted copy when the dict uses diffusers-port naming, else
+    the dict unchanged. Idempotent: converted output carries no markers."""
+    if not is_diffusers_lora(state_dict):
+        return state_dict
+    print("Converting Krea 2 Lora from Diffusers naming to native naming")
+    converted = {}
+    for key, value in state_dict.items():
+        for search, replace in _RENAME_RULES:
+            if search in key:
+                key = key.replace(search, replace)
+        converted[key] = value
+    return converted


### PR DESCRIPTION
## Problem

A sizable share of Krea 2 LoRAs on Civitai fail to load with
`Lora '...' contains unexpected module keys` — reported in #1994 (~20–25% of
one user's collection). These LoRAs were trained against the **diffusers port**
of Krea 2 and use its module naming (`transformer_blocks.N.attn.to_q`,
`text_fusion.…`, `ff.up/gate/down`), while WanGP's implementation uses the
original checkpoint naming (`blocks.N.attn.wq`, `txtfusion.…`,
`mlp.up/gate/down`).

Note this is *not* the ai-toolkit class: ai-toolkit saves Krea 2 LoRAs in the
native naming already and those load fine. The failing files come from
trainers that target the diffusers port (e.g. OneTrainer's Krea2 template —
see the OneTrainer report in #1994).

## Fix

`preprocess_loras` on krea2's `SingleStreamDiT` — the same auto-discovered
hook flux/qwen/wan/ltx2 already use — plus a small torch-free converter module
(`models/krea2/lora_convert.py`).

- Detection is content-based per file (diffusers markers in the key names);
  native-keyed and kohya dicts pass through untouched, and conversion is
  idempotent.
- The mapping is a pure 1:1 key rename — both implementations use unfused
  attention and the same SwiGLU layout, so no tensor is modified:

| diffusers port | WanGP native |
|---|---|
| `img_in` | `first` |
| `transformer_blocks.N.attn.to_q / to_k / to_v / to_gate` | `blocks.N.attn.wq / wk / wv / gate` |
| `…attn.to_out.0` | `…attn.wo` |
| `…ff.up / gate / down` | `…mlp.up / gate / down` |
| `text_fusion.*` | `txtfusion.*` |
| `time_embed.linear_1 / linear_2` | `tmlp.0 / tmlp.2` |
| `time_mod_proj` | `tproj.1` |
| `txt_in.linear_1 / linear_2` | `txtmlp.1 / txtmlp.3` |
| `final_layer.linear` | `last.linear` |

Rules are suffix-agnostic, so `.lora_A/.lora_B`, `.lora_down/.lora_up`,
`.alpha` and `.dora_scale` keys all convert consistently.

## Testing

- **Unit**: against the full 528-key inventory of a real failing Civitai LoRA
  (a "retro anime" style LoRA from the #1994 class): every converted key lands
  on an existing module of `SingleStreamDiT` (all 264 targeted modules
  covered), no collisions, A/B suffix pairs preserved, `.alpha` keys handled,
  second pass is a no-op, native/kohya dicts returned unchanged.
- **Live**: the same LoRA previously hard-failed at load; with this patch it
  loads and generates, and a same-seed A/B (with vs. without the LoRA, style
  phrase in the prompt) shows the expected strong retro-cel style shift —
  i.e. the remapped weights genuinely apply, not just load.
- **Regression**: native-keyed LoRAs (Identity Edit v1.2, ai-toolkit-trained
  files, FLUX-style sliders) load exactly as before via the passthrough.

Fixes the Krea 2 portion of #1994.

🤖 Generated with [Claude Code](https://claude.com/claude-code)