### PR TITLE
Krea 2: Ostris reference-edit conditioning mode (style transfer from a reference image)

### DIFF
--- a/defaults/krea2_turbo_ostris_edit.json
+++ b/defaults/krea2_turbo_ostris_edit.json
@@ -1,0 +1,14 @@
+{
+    "model": {
+        "name": "Krea 2 Turbo Ostris Edit",
+        "architecture": "krea2_turbo_ostris_edit",
+        "description": "Krea 2 Turbo with Ostris's reference-edit conditioning: Reference Images are described to the text encoder with 'Picture N' vision markers and their clean latents ride at the end of the sequence at t=0. On its own this mode does little - activate a Krea 2 edit LoRA trained with ai-toolkit's edit mode (such as Style Reference or Detail Enhancer, available as dedicated finetunes) to give it a function.",
+        "URLs": "krea2_turbo"
+    },
+    "prompt": "a woman walking her dog on a city street",
+    "negative_prompt": "",
+    "video_prompt_type": "I",
+    "batch_size": 1,
+    "num_inference_steps": 8,
+    "guidance_scale": 0
+}

--- a/defaults/krea2_turbo_ostris_style_ref.json
+++ b/defaults/krea2_turbo_ostris_style_ref.json
@@ -1,0 +1,16 @@
+{
+    "model": {
+        "name": "Krea 2 Turbo Ostris Style Reference",
+        "architecture": "krea2_turbo_ostris_edit",
+        "description": "Krea 2 Turbo with Ostris's Style Reference LoRA: add one or more style Reference Images and the prompt is rendered in their style (Ostris edit conditioning: 'Picture N' vision markers + clean reference tokens appended at t=0).",
+        "URLs": "krea2_turbo",
+        "loras": ["https://huggingface.co/ostris/krea2_turbo_style_reference/resolve/main/krea2_style_reference.safetensors"],
+        "loras_multipliers": [1]
+    },
+    "prompt": "a woman walking her dog on a city street",
+    "negative_prompt": "",
+    "video_prompt_type": "I",
+    "batch_size": 1,
+    "num_inference_steps": 8,
+    "guidance_scale": 0
+}

--- a/models/krea2/krea2_handler.py
+++ b/models/krea2/krea2_handler.py
@@ -16,6 +16,7 @@ _RAW_MODEL_TYPE = "krea2_raw"
 _TURBO_MODEL_TYPE = "krea2_turbo"
 _RAW_EDIT_MODEL_TYPE = "krea2_raw_edit"
 _TURBO_EDIT_MODEL_TYPE = "krea2_turbo_edit"
+_TURBO_OSTRIS_EDIT_MODEL_TYPE = "krea2_turbo_ostris_edit"
 _PROFILE_DIR = "krea2"
 _PRESET_PROFILE_DIR = "krea2_presets"
 
@@ -69,6 +70,32 @@ class family_handler:
             "vae_upsamplers": {"qwen_vae_pid(1.5)": [1]},
             "excluded_spatial_upsamplers": ["qwen_pid(1.5)"],
         }
+        if base_model_type == _TURBO_OSTRIS_EDIT_MODEL_TYPE:
+            # Ostris reference conditioning (t=0 reference tokens at the sequence tail), for LoRAs
+            # trained with ai-toolkit's krea2 edit mode. Plain "I" references only — no "K" concept,
+            # no inpainting, and reference backgrounds must be kept (a style ref IS its background).
+            result.update({
+                "ostris_edit": True,
+                "inpaint_support": False,
+                "image_ref_choices": {
+                    "choices": [
+                        ("None", ""),
+                        ("Reference Images the model draws content / style from", "I"),
+                    ],
+                    "letters_filter": "I",
+                    "default": "I",
+                },
+                "at_least_one_image_ref_needed": True,
+                # Vision tower comes from the same standalone checkpoint the identity-edit
+                # models use (upstream split it out of the combined VL file).
+                "vision_encoder_filename": os.path.join(_TEXT_ENCODER_FOLDER, _VISION_ENCODER_FILENAME),
+                "preload_URLs": [
+                    build_hf_url(_PROJECT_REPO, _TEXT_ENCODER_FOLDER, _VISION_ENCODER_FILENAME)
+                    + f"|{_TEXT_ENCODER_FOLDER}"
+                ],
+            })
+            result.pop("guide_custom_choices_image", None)
+            result.pop("model_modes", None)
         if edit:
             result.update({
                 "inpaint_support": True,
@@ -103,11 +130,11 @@ class family_handler:
 
     @staticmethod
     def query_supported_types():
-        return [_RAW_MODEL_TYPE, _TURBO_MODEL_TYPE, _RAW_EDIT_MODEL_TYPE, _TURBO_EDIT_MODEL_TYPE]
+        return [_RAW_MODEL_TYPE, _TURBO_MODEL_TYPE, _RAW_EDIT_MODEL_TYPE, _TURBO_EDIT_MODEL_TYPE, _TURBO_OSTRIS_EDIT_MODEL_TYPE]
 
     @staticmethod
     def query_family_maps():
-        compatible = [_RAW_MODEL_TYPE, _TURBO_MODEL_TYPE, _RAW_EDIT_MODEL_TYPE, _TURBO_EDIT_MODEL_TYPE]
+        compatible = [_RAW_MODEL_TYPE, _TURBO_MODEL_TYPE, _RAW_EDIT_MODEL_TYPE, _TURBO_EDIT_MODEL_TYPE, _TURBO_OSTRIS_EDIT_MODEL_TYPE]
         return {}, {model_type: compatible for model_type in compatible}
 
     @staticmethod
@@ -186,13 +213,16 @@ class family_handler:
     @staticmethod
     def update_default_settings(base_model_type, model_def, ui_defaults):
         edit = base_model_type in (_RAW_EDIT_MODEL_TYPE, _TURBO_EDIT_MODEL_TYPE)
-        ui_defaults.update({"image_mode": 1, "batch_size": 1, "model_mode": 0 if edit else 2, "denoising_strength": 1.0, "masking_strength": 1.0})
-        if base_model_type in (_TURBO_MODEL_TYPE, _TURBO_EDIT_MODEL_TYPE):
+        ostris_edit = base_model_type == _TURBO_OSTRIS_EDIT_MODEL_TYPE
+        ui_defaults.update({"image_mode": 1, "batch_size": 1, "model_mode": 0 if edit or ostris_edit else 2, "denoising_strength": 1.0, "masking_strength": 1.0})
+        if base_model_type in (_TURBO_MODEL_TYPE, _TURBO_EDIT_MODEL_TYPE, _TURBO_OSTRIS_EDIT_MODEL_TYPE):
             ui_defaults.update({"num_inference_steps": 8, "guidance_scale": 0, "resolution": "1024x1024"})
         else:
             ui_defaults.update({"num_inference_steps": 20 if base_model_type == _RAW_EDIT_MODEL_TYPE else 52, "guidance_scale": 2 if base_model_type == _RAW_EDIT_MODEL_TYPE else 3.5, "resolution": "1024x1024"})
         if edit:
             ui_defaults.update({"video_prompt_type": "KI", "remove_background_images_ref": 0})
+        elif ostris_edit:
+            ui_defaults.update({"video_prompt_type": "I", "remove_background_images_ref": 0})
 
     @staticmethod
     def fix_settings(base_model_type, settings_version, model_def, ui_defaults):
@@ -227,6 +257,8 @@ class family_handler:
             max_refs = 1 if inputs.get("image_mode") == 2 else 2
             if len(inputs.get("image_refs") or []) > max_refs:
                 return "Krea 2 Edit supports at most two Reference Images."
+        if base_model_type == _TURBO_OSTRIS_EDIT_MODEL_TYPE and len(inputs.get("image_refs") or []) > 3:
+            return "Krea 2 Ostris Edit supports at most three Reference Images."
         model_mode_int = family_handler.normalize_lanpaint_strengths(inputs)
         if inputs.get("denoising_strength", 1) < 1 and model_mode_int != 0:
             gr.Info("Denoising Strength will be ignored if Masked Denoising is not used")

--- a/models/krea2/krea2_main.py
+++ b/models/krea2/krea2_main.py
@@ -105,10 +105,17 @@ class Qwen3VLConditioner(torch.nn.Module):
         self.prompt_template_encode_start_idx = 34
         self.prompt_template_encode_suffix_start_idx = 5
 
-    def _tokenize(self, text: list[str], device, images=None):
+    def _tokenize(self, text: list[str], device, images=None, picture_markers=False):
         prefix_idx = self.prompt_template_encode_start_idx
         target_device = torch.device(device)
-        vision = "" if images is None else "<|vision_start|><|image_pad|><|vision_end|>" * len(images)
+        if images is None:
+            vision = ""
+        elif picture_markers:
+            # Ostris edit conditioning: each reference is introduced by a "Picture N:" marker
+            # (string copied verbatim from the ai-toolkit / ComfyUI-Krea2-Ostris-Edit implementation).
+            vision = "".join("Picture {}: <|vision_start|><|image_pad|><|vision_end|>".format(image_no) for image_no in range(1, len(images) + 1))
+        else:
+            vision = "<|vision_start|><|image_pad|><|vision_end|>" * len(images)
         prefixed_text = [self.prompt_template_encode_prefix + vision + item for item in text]
         suffix_text = [self.prompt_template_encode_suffix] * len(text)
         # Tokenizers create PyTorch tensors via the global default device; pin that choice here so MMGP
@@ -128,11 +135,11 @@ class Qwen3VLConditioner(torch.nn.Module):
         return input_ids, mask, position_ids, prefix_idx, inputs
 
     @torch.inference_mode()
-    def forward(self, text: list[str], device, images=None):
+    def forward(self, text: list[str], device, images=None, picture_markers=False):
         self.qwen.language_model._interrupt = getattr(self, "_interrupt", False)
         if getattr(self, "_interrupt", False):
             return None, None
-        input_ids, mask, position_ids, prefix_idx, inputs = self._tokenize(text, device=device, images=images)
+        input_ids, mask, position_ids, prefix_idx, inputs = self._tokenize(text, device=device, images=images, picture_markers=picture_markers)
         inputs_embeds = visual_pos_masks = deepstack_visual_embeds = None
         if images is not None:
             image_grid_thw = inputs["image_grid_thw"]
@@ -200,11 +207,20 @@ class Krea2Pipeline:
         latents = (latents * latents_std) + latents_mean
         return self.vae.decode_to_cpu_uint8(latents)[:, :, 0]
 
-    def _encode_image_to_latents(self, image, width, height, device, dtype, fit=False, resize_to_target=True):
+    def _encode_image_to_latents(self, image, width, height, device, dtype, fit=False, resize_to_target=True, fit_area=None):
         from shared.utils.utils import convert_image_to_tensor
 
         image = image.convert("RGB")
-        if fit:
+        if fit_area is not None:
+            # Ostris edit references: fit into fit_area pixels (downscale only), keep aspect,
+            # snap dims to the latent grid (round, like the reference implementation). BOX ~ "area" resampling.
+            snap = self.compression * self.transformer.config.patch
+            scale = min(1.0, math.sqrt(fit_area / (image.width * image.height)))
+            fit_width = max(round(image.width * scale / snap) * snap, snap)
+            fit_height = max(round(image.height * scale / snap) * snap, snap)
+            if (fit_width, fit_height) != (image.width, image.height):
+                image = image.resize((fit_width, fit_height), resample=Image.Resampling.BOX)
+        elif fit:
             image_width, image_height = image.size
             scale = min(height / image_height, width / image_width)
             if image_height * scale >= height * 0.92 and image_width * scale >= width * 0.92:
@@ -245,12 +261,12 @@ class Krea2Pipeline:
         image = image.convert("RGB").resize((width, height), resample=Image.Resampling.LANCZOS)
         return convert_image_to_tensor(image).add(1).mul(127.5).round().clamp(0, 255).to(torch.uint8).unsqueeze(0)
 
-    def _encode_prompts(self, prompts, device, dtype, images=None):
+    def _encode_prompts(self, prompts, device, dtype, images=None, picture_markers=False):
         self.encoder._interrupt = self._interrupt
         self.encoder.qwen.language_model._interrupt = self._interrupt
 
         def encode_fn(prompt_batch):
-            hiddens, masks = self.encoder(prompt_batch, device=device, images=images)
+            hiddens, masks = self.encoder(prompt_batch, device=device, images=images, picture_markers=picture_markers)
             if hiddens is None:
                 raise _TextEncodingInterrupted
             return [(hiddens[i], masks[i]) for i in range(len(prompt_batch))]
@@ -296,6 +312,7 @@ class Krea2Pipeline:
         reference_images=None,
         fit_all_references=False,
         reference_offsets=None,
+        ostris_edit=False,
         vae_upsampler=None,
         vae_upsampler_seed: int = 0,
         vae_upsampler_progress_callback=None,
@@ -314,16 +331,23 @@ class Krea2Pipeline:
         for i in range(batch_size):
             noise[i]= torch.randn(self.channels, height // self.compression, width // self.compression, device=device, dtype=dtype, generator=torch.Generator(device=device).manual_seed(int(seed) + i))
         edit = bool(reference_images)
+        ostris = bool(ostris_edit) and edit
         grounding_images = None
         if edit:
             grounding_images = []
             for image in reference_images:
                 image = image.convert("RGB")
-                if max(image.size) > 768:
+                if ostris:
+                    # Ostris edit conditioning: the vision tower sees a coarse reference fit to
+                    # 384x384 total pixels (downscale only, aspect kept).
+                    scale = min(1.0, math.sqrt(384 * 384 / (image.width * image.height)))
+                    if scale < 1.0:
+                        image = image.resize((max(round(image.width * scale), 1), max(round(image.height * scale), 1)), Image.Resampling.BOX)
+                elif max(image.size) > 768:
                     scale = 768 / max(image.size)
                     image = image.resize((round(image.width * scale), round(image.height * scale)), Image.Resampling.LANCZOS)
                 grounding_images.append(image)
-        txt, txtmask = self._encode_prompts(prompts, device, dtype, images=grounding_images)
+        txt, txtmask = self._encode_prompts(prompts, device, dtype, images=grounding_images, picture_markers=ostris)
         if txt is None:
             return None
         cfg = guidance > 0
@@ -332,7 +356,7 @@ class Krea2Pipeline:
         nagtxt = nagtxtmask = None
         context_len = txt.shape[1]
         if float(NAG_scale) > 1.0 and not cfg:
-            nagtxt, nagtxtmask = self._encode_prompts(negative_prompts, device, dtype, images=grounding_images)
+            nagtxt, nagtxtmask = self._encode_prompts(negative_prompts, device, dtype, images=grounding_images, picture_markers=ostris)
             if nagtxt is None:
                 return None
             context_len = max(txt.shape[1], nagtxt.shape[1])
@@ -341,7 +365,7 @@ class Krea2Pipeline:
             NAG = {"scale": float(NAG_scale), "tau": float(NAG_tau), "alpha": float(NAG_alpha), "cap_embed_len": context_len, "prefix_len": 0}
         x, pos, mask = _prepare(noise, context_len, patch, txtmask)
         if cfg:
-            untxt, untxtmask = self._encode_prompts(negative_prompts, device, dtype, images=grounding_images)
+            untxt, untxtmask = self._encode_prompts(negative_prompts, device, dtype, images=grounding_images, picture_markers=ostris)
             if untxt is None:
                 return None
             _, unpos, unmask = _prepare(noise, untxt.shape[1], patch, untxtmask)
@@ -350,7 +374,27 @@ class Krea2Pipeline:
         ts = _timesteps(x.shape[1], steps, x1, x2, y1=y1, y2=y2, mu=mu)
         img = x
         reference_tokens = []
-        if edit:
+        if edit and ostris:
+            reference_positions = []
+            reference_masks = []
+            for frame_no, image in enumerate(reference_images, start=1):
+                latents = self._encode_image_to_latents(image, width, height, device, dtype, fit_area=1024 * 1024)
+                grid_h, grid_w = latents.shape[-2] // patch, latents.shape[-1] // patch
+                reference_tokens.append(_pack_image_latents(latents, patch).expand(batch_size, -1, -1).contiguous())
+                # RoPE: axis 0 = reference index (1-based), y/x grids 0-based (no target-grid centering).
+                ref_pos = torch.zeros(batch_size, grid_h * grid_w, 3, device=device)
+                ref_pos[..., 0] = frame_no
+                ref_pos[..., 1] = torch.arange(grid_h, device=device).view(-1, 1).expand(grid_h, grid_w).reshape(-1)
+                ref_pos[..., 2] = torch.arange(grid_w, device=device).view(1, -1).expand(grid_h, grid_w).reshape(-1)
+                reference_positions.append(ref_pos)
+                reference_masks.append(torch.ones(batch_size, grid_h * grid_w, device=device, dtype=torch.bool))
+            # References ride at the tail of the sequence (after the noisy target tokens).
+            pos = torch.cat([pos] + reference_positions, dim=1)
+            mask = torch.cat([mask] + reference_masks, dim=1)
+            if cfg:
+                unpos = torch.cat([unpos] + reference_positions, dim=1)
+                unmask = torch.cat([unmask] + reference_masks, dim=1)
+        elif edit:
             target_grid_h, target_grid_w = height // align, width // align
             reference_positions = []
             reference_masks = []
@@ -371,8 +415,9 @@ class Krea2Pipeline:
             if cfg:
                 unpos = torch.cat([unpos[:, :untxt.shape[1]]] + reference_positions + [unpos[:, untxt.shape[1]:]], dim=1)
                 unmask = torch.cat([unmask[:, :untxt.shape[1]]] + reference_masks + [unmask[:, untxt.shape[1]:]], dim=1)
+        reference_len = sum(tokens.shape[1] for tokens in reference_tokens)
         if NAG is not None:
-            NAG["query_start"] = context_len + sum(tokens.shape[1] for tokens in reference_tokens)
+            NAG["query_start"] = context_len if ostris else context_len + reference_len
             NAG["query_end"] = NAG["query_start"] + img.shape[1]
         self.transformer._interrupt = self._interrupt
         model_mode_int = None
@@ -446,15 +491,25 @@ class Krea2Pipeline:
                 if untxt is None:
                     return None
         t_values = torch.tensor(ts[:-1], dtype=img.dtype, device=img.device)
+        # Ostris edit conditioning: the clean reference span modulates with a t=0 vector.
+        ostris_refs = ostris and reference_len > 0
+        zero_t = torch.zeros_like(t_values[:1])
+        ref_step_tvecs = None
         if timestep_static:
             offload.set_step_no_for_lora(self.transformer, 0)
             t_all, tvec_all = self.transformer.prepare_timestep(t_values)
             step_tensors = tuple((t_all[i : i + 1], tvec_all[i : i + 1]) for i in range(updated_steps))
+            if ostris_refs:
+                _, ref_tvec = self.transformer.prepare_timestep(zero_t)
+                ref_step_tvecs = (ref_tvec,) * updated_steps
         else:
             step_tensors = []
+            ref_step_tvecs = [] if ostris_refs else None
             for step_no, tcurr in enumerate(t_values):
                 offload.set_step_no_for_lora(self.transformer, step_offset + step_no)
                 step_tensors.append(self.transformer.prepare_timestep(tcurr[None]))
+                if ostris_refs:
+                    ref_step_tvecs.append(self.transformer.prepare_timestep(zero_t)[1])
         torch.cuda.empty_cache()
         for i, (tcurr, tprev) in enumerate(tqdm(list(zip(ts[:-1], ts[1:])), total=updated_steps)):
             offload.set_step_no_for_lora(self.transformer, step_offset + i)
@@ -462,9 +517,15 @@ class Krea2Pipeline:
             if self._interrupt:
                 return None
             t, tvec = step_tensors[i]
+            ref_kwargs = {"ref_len": reference_len, "ref_tvec": ref_step_tvecs[i]} if ostris_refs else {}
 
             def run_model(latents, cfg_scale):
-                model_latents = torch.cat(reference_tokens + [latents], dim=1) if edit else latents
+                if not edit:
+                    model_latents = latents
+                elif ostris:
+                    model_latents = torch.cat([latents] + reference_tokens, dim=1)
+                else:
+                    model_latents = torch.cat(reference_tokens + [latents], dim=1)
                 step_txt = txt if context_static else self.transformer.prepare_context(txt, mask, context_len)
                 if step_txt is None:
                     return None, None
@@ -477,13 +538,13 @@ class Krea2Pipeline:
                     step_untxt = untxt if context_static else self.transformer.prepare_context(untxt, unmask)
                     if step_untxt is None:
                         return None, None
-                    cond, uncond = self.transformer.forward_cfg(img=model_latents, context=step_txt, uncond_context=step_untxt, t=t, tvec=tvec, pos=pos, uncond_pos=unpos, mask=mask, uncond_mask=unmask, target_len=latents.shape[1])
+                    cond, uncond = self.transformer.forward_cfg(img=model_latents, context=step_txt, uncond_context=step_untxt, t=t, tvec=tvec, pos=pos, uncond_pos=unpos, mask=mask, uncond_mask=unmask, target_len=latents.shape[1], **ref_kwargs)
                     if cond is None or uncond is None:
                         return None, None
                     if not torch.isfinite(cond).all() or not torch.isfinite(uncond).all():
                         raise RuntimeError("Krea 2 produced non-finite CFG denoiser predictions.")
                     return cond, uncond
-                cond = self.transformer(img=model_latents, context=step_txt, t=t, tvec=tvec, pos=pos, mask=mask, NAG=NAG, neg_context=step_nagtxt, neg_mask=nagtxtmask, target_len=latents.shape[1])
+                cond = self.transformer(img=model_latents, context=step_txt, t=t, tvec=tvec, pos=pos, mask=mask, NAG=NAG, neg_context=step_nagtxt, neg_mask=nagtxtmask, target_len=latents.shape[1], **ref_kwargs)
                 if cond is None:
                     return None, None
                 if not torch.isfinite(cond).all():
@@ -729,14 +790,16 @@ class model_factory:
         text_encoder_folder = model_def["text_encoder_folder"]
         text_encoder_config_path = fl.locate_file(os.path.join(text_encoder_folder, "config.json"))
         edit = base_model_type in ("krea2_raw_edit", "krea2_turbo_edit")
+        ostris_edit = bool((model_def or {}).get("ostris_edit"))
+        with_vision = edit or ostris_edit
         vision_encoder_filename = None
-        if edit:
+        if with_vision:
             vision_encoder_filename = fl.locate_file(model_def["vision_encoder_filename"])
         text_encoder = _load_text_encoder(
             text_encoder_filename,
             text_encoder_config_path,
             dtype,
-            with_vision=edit,
+            with_vision=with_vision,
             vision_encoder_filename=vision_encoder_filename,
         )
         tokenizer_config = fl.locate_file(os.path.join(text_encoder_folder, "tokenizer_config.json"))
@@ -794,7 +857,8 @@ class model_factory:
             else:
                 self.vae.disable_tiling()
         identity_edit = self.base_model_type in ("krea2_raw_edit", "krea2_turbo_edit")
-        turbo = self.base_model_type in ("krea2_turbo", "krea2_turbo_edit")
+        ostris_edit = bool((self.model_def or {}).get("ostris_edit"))
+        turbo = self.base_model_type in ("krea2_turbo", "krea2_turbo_edit", "krea2_turbo_ostris_edit")
         if turbo:
             guide_scale = 0
             kwargs_mu = 1.15
@@ -870,6 +934,7 @@ class model_factory:
             reference_images=reference_images,
             fit_all_references="I" in video_prompt_type and "K" not in video_prompt_type,
             reference_offsets=reference_offsets,
+            ostris_edit=ostris_edit,
             vae_upsampler=vae_upsampler,
             vae_upsampler_seed=generator_seed,
             vae_upsampler_progress_callback=_vae_upsampler_progress,

--- a/models/krea2/krea2_mmdit.py
+++ b/models/krea2/krea2_mmdit.py
@@ -418,7 +418,11 @@ class SingleStreamBlock(nn.Module):
         NAG: dict | None = None,
         neg_context: Tensor | None = None,
         neg_mask: Tensor | None = None,
+        ref_vec: Tensor | None = None,
+        ref_split: int | None = None,
     ) -> Tensor:
+        if ref_vec is not None:
+            return self.forward_ref_span(x, vec, ref_vec, ref_split, freqs, mask, txt_len=txt_len, NAG=NAG, neg_context=neg_context, neg_mask=neg_mask)
         prescale, preshift, pregate, postscale, postshift, postgate = self.mod(vec)
         x_list = [self.prenorm(x)]
         modulate_inplace(x_list, prescale, preshift)
@@ -434,6 +438,52 @@ class SingleStreamBlock(nn.Module):
         modulate_inplace(x_list, postscale, postshift)
         mlp_out = self.mlp(x_list)
         mlp_out.mul_(postgate)
+        x.add_(mlp_out)
+        del mlp_out
+        return x
+
+    def forward_ref_span(
+        self,
+        x: Tensor,
+        vec: Tensor,
+        ref_vec: Tensor,
+        split: int,
+        freqs: Tensor,
+        mask: Tensor | None = None,
+        txt_len: int | None = None,
+        NAG: dict | None = None,
+        neg_context: Tensor | None = None,
+        neg_mask: Tensor | None = None,
+    ) -> Tensor:
+        # Ostris edit conditioning: tokens [:split] (text + noisy target) modulate with the
+        # real-t vec, tokens [split:] (clean reference tokens, plus stream padding) with the
+        # t=0 ref_vec — attention still runs over the whole sequence.
+        if split is None:
+            raise ValueError("Krea 2 reference-span block forward requires an explicit split index.")
+        prescale, preshift, pregate, postscale, postshift, postgate = self.mod(vec)
+        ref_prescale, ref_preshift, ref_pregate, ref_postscale, ref_postshift, ref_postgate = self.mod(ref_vec)
+        x_norm = self.prenorm(x)
+        x_norm[:, :split].mul_(prescale.add_(1)).add_(preshift)
+        x_norm[:, split:].mul_(ref_prescale.add_(1)).add_(ref_preshift)
+        if NAG is not None:
+            neg_context = self.prenorm(neg_context)
+            neg_context.mul_(prescale).add_(preshift)
+        x_list = [x_norm]
+        x_norm = None
+        attn_out = self.attn(x_list, freqs, mask, txt_len=txt_len, NAG=NAG, neg_context=neg_context, neg_mask=neg_mask)
+        neg_context = neg_mask = None
+        attn_out[:, :split].mul_(pregate)
+        attn_out[:, split:].mul_(ref_pregate)
+        x.add_(attn_out)
+        del attn_out
+        x_norm = self.postnorm(x)
+        x_norm[:, :split].mul_(postscale.add_(1)).add_(postshift)
+        x_norm[:, split:].mul_(ref_postscale.add_(1)).add_(ref_postshift)
+        x_list = [x_norm]
+        x_norm = None
+        mlp_out = self.mlp(x_list)
+        mlp_out[:, :split].mul_(postgate)
+        mlp_out[:, split:].mul_(ref_postgate)
         x.add_(mlp_out)
         del mlp_out
         return x
@@ -568,30 +618,47 @@ class SingleStreamDiT(nn.Module):
         neg_context: Tensor | None = None,
         neg_mask: Tensor | None = None,
         target_len: int | None = None,
+        ref_len: int = 0,
+        ref_tvec: Tensor | None = None,
     ) -> Tensor:
+        if ref_len > 0 and ref_tvec is None:
+            raise ValueError("Krea 2 reference-span forward requires a t=0 ref_tvec.")
         img = self.first(img)
         combined, txtlen, imglen, freqs, mask = self._build_stream(img, context, pos, mask)
         del img, context, pos
+        ref_split = txtlen + imglen - ref_len if ref_len > 0 else None
         for block in self.blocks:
-            combined = block(combined, tvec, freqs, mask, txt_len=txtlen, NAG=NAG, neg_context=neg_context, neg_mask=neg_mask)
+            combined = block(combined, tvec, freqs, mask, txt_len=txtlen, NAG=NAG, neg_context=neg_context, neg_mask=neg_mask, ref_vec=ref_tvec if ref_len > 0 else None, ref_split=ref_split)
             if getattr(self, "_interrupt", False):
                 return None
             self.txtfusion._interrupt = getattr(self, "_interrupt", False)
+        if ref_len > 0:
+            # References ride at the tail of the sequence: the denoised target is the front of the image span.
+            target_len = imglen - ref_len if target_len is None else target_len
+            return self.last([combined[:, txtlen : txtlen + target_len]], t)
         target_len = imglen if target_len is None else target_len
         return self.last([combined[:, txtlen + imglen - target_len : txtlen + imglen]], t)
 
-    def forward_cfg(self, img: Tensor, context: Tensor, uncond_context: Tensor, t: Tensor, tvec: Tensor, pos: Tensor, uncond_pos: Tensor, mask: Tensor, uncond_mask: Tensor, target_len: int | None = None) -> tuple[Tensor | None, Tensor | None]:
+    def forward_cfg(self, img: Tensor, context: Tensor, uncond_context: Tensor, t: Tensor, tvec: Tensor, pos: Tensor, uncond_pos: Tensor, mask: Tensor, uncond_mask: Tensor, target_len: int | None = None, ref_len: int = 0, ref_tvec: Tensor | None = None) -> tuple[Tensor | None, Tensor | None]:
+        if ref_len > 0 and ref_tvec is None:
+            raise ValueError("Krea 2 reference-span forward requires a t=0 ref_tvec.")
         img = self.first(img)
         share_freqs = pos.shape == uncond_pos.shape
         combined, txtlen, imglen, freqs, mask = self._build_stream(img, context, pos, mask)
         uncond_combined, uncond_txtlen, uncond_imglen, uncond_freqs, uncond_mask = self._build_stream(img, uncond_context, uncond_pos, uncond_mask, freqs=freqs if share_freqs else None)
         del img, context, uncond_context, pos, uncond_pos
+        block_ref_vec = ref_tvec if ref_len > 0 else None
+        ref_split = txtlen + imglen - ref_len if ref_len > 0 else None
+        uncond_ref_split = uncond_txtlen + uncond_imglen - ref_len if ref_len > 0 else None
         for block in self.blocks:
-            combined = block(combined, tvec, freqs, mask)
+            combined = block(combined, tvec, freqs, mask, ref_vec=block_ref_vec, ref_split=ref_split)
             if getattr(self, "_interrupt", False):
                 return None, None
-            uncond_combined = block(uncond_combined, tvec, uncond_freqs, uncond_mask)
+            uncond_combined = block(uncond_combined, tvec, uncond_freqs, uncond_mask, ref_vec=block_ref_vec, ref_split=uncond_ref_split)
             if getattr(self, "_interrupt", False):
                 return None, None
+        if ref_len > 0:
+            target_len = imglen - ref_len if target_len is None else target_len
+            return self.last([combined[:, txtlen : txtlen + target_len]], t), self.last([uncond_combined[:, uncond_txtlen : uncond_txtlen + target_len]], t)
         target_len = imglen if target_len is None else target_len
         return self.last([combined[:, txtlen + imglen - target_len : txtlen + imglen]], t), self.last([uncond_combined[:, uncond_txtlen + uncond_imglen - target_len : uncond_txtlen + uncond_imglen]], t)


### PR DESCRIPTION
## Problem

Krea 2 has two *different* reference-image conditioning schemes, and WanGP
currently implements only one.

The supported one is the Identity Edit scheme (`krea2_*_edit`): reference latents
are prepended **before** the noisy target tokens, RoPE-centered on the target
grid, everything modulated with the real timestep. That's the right wiring for
"preserve this subject and edit it".

The other one is what [ai-toolkit](https://github.com/ostris/ai-toolkit) trains
with its `edit` mode and what
[ComfyUI-Krea2-Ostris-Edit](https://github.com/ostris/ComfyUI-Krea2-Ostris-Edit)
runs. LoRAs of that class **already load** in WanGP — ai-toolkit saves Krea 2
LoRAs in the native key naming — but they are inert, because the conditioning
they were trained against isn't there. The LoRA supplies the behavior; the mode
has to enable it. The practical gap: Krea 2 in WanGP has no
style-from-a-reference-image at all, and no way to run the growing set of
community `krea2` edit LoRAs.

## What this adds

A new base type `krea2_turbo_ostris_edit` implementing that scheme, plus two
model defs:

| Model def | Purpose |
|---|---|
| `krea2_turbo_ostris_edit` | the bare mode — pair it with any ai-toolkit krea2 edit LoRA you activate yourself |
| `krea2_turbo_ostris_style_ref` | finetune pinning [ostris/krea2_turbo_style_reference](https://huggingface.co/ostris/krea2_turbo_style_reference) → style transfer from reference images |

## Mechanism

Matched to the reference implementation:

- **Prompt**: each reference is introduced to the vision-enabled text encoder
  with a `Picture N: <|vision_start|><|image_pad|><|vision_end|>` marker (string
  copied verbatim) instead of the bare vision-pad triple.
- **Grounding refs**: fit to 384×384 *total pixels* (downscale only, aspect
  kept) rather than the identity-edit path's 768-max.
- **Reference latents**: fit into ≤1 MP, dims snapped to the latent grid,
  BOX/area resampling.
- **Sequence order**: reference tokens ride at the **tail**, after the noisy
  target tokens (identity edit puts them in front), with 0-based per-ref RoPE
  grids — axis 0 = 1-based reference index, no target-grid centering. The
  denoised output is therefore the **front** of the image span.
- **Timestep**: the clean reference span modulates with a **t = 0** vector while
  text + noisy target keep the real-t vector. That's the actual crux — a single
  timestep vector for the whole sequence produces the wrong result even with the
  rest of the wiring correct. Implemented as
  `SingleStreamBlock.forward_ref_span` (per-span modulation; attention still
  runs over the whole sequence) plus `ref_len` / `ref_tvec` on
  `SingleStreamDiT.forward` / `forward_cfg`. The t=0 vec is computed per step so
  both the static and dynamic LoRA-schedule paths work.

NAG composes: the negative-text query span is the noise span, so
`query_start` is `context_len` here rather than `context_len + reference_len`,
and the negative context keeps the real-t modulation.

## No behavior change for existing models

Every new path is guarded on `ref_vec is not None` / `ref_len > 0`, and no
existing model type sets either. Verified rather than asserted — a CPU test
config loading this branch's `krea2_mmdit.py` and the `main` version side by
side, same weights, same inputs:

| Check | Result |
|---|---|
| `SingleStreamBlock.forward`, default path | bitwise identical (max abs Δ = 0) |
| `SingleStreamDiT.forward`, default path | bitwise identical |
| `SingleStreamDiT.forward_cfg`, default path | bitwise identical |
| per-span forward with `ref_vec == vec` | reduces to the single-span forward, bitwise |
| tail-ref forward | returns the front (target) span, matching the equivalent full-sequence run |
| `ref_len > 0` without `ref_tvec` | raises |

## Live results

RTX 5080, Turbo 8-step path, `krea2_turbo_ostris_style_ref`:

- **Style Reference LoRA + this mode**: full restyle — the prompt's content
  rendered in the reference's style, palette and texture carried over
  (reference-palette histogram intersection 0.49 vs 0.32 for the unstyled
  baseline). Same prompt and seed on base `krea2_turbo` comes back photoreal.
- **Control — this mode with no LoRA loaded**: the model parrots the reference
  and largely ignores the prompt. Consistent with the LoRA carrying the behavior
  and the mode only enabling it, and a useful sanity check that the mode itself
  isn't doing the styling.
- **Control — the same LoRA on the identity-edit mode**: partial transfer only
  (histogram intersection 0.37). The two schemes are not interchangeable, which
  is why this is a separate base type rather than a flag.

## Notes

- **Why a new base type instead of an option on `krea2_turbo_edit`:** the two
  conditioning schemes are mutually exclusive in wiring (refs before vs. after
  the noise, different prompt markers, different reference sizing, single vs.
  per-span timestep modulation), and WanGP pairs a LoRA with its conditioning
  through the model def. A flag would mean a user could select the combination
  that produces garbage.
- **Both defaults JSONs are needed:** the models selector resolves
  `get_model_def(base_model_type).get("parent_model_type", ...)` without a
  None-check, so an architecture with no same-named defaults file crashes
  `create_ui` at startup. `defaults/krea2_turbo_ostris_edit.json` is that file —
  it isn't vestigial — and it doubles as the bare mode for hand-activated LoRAs.
- **Vision encoder:** reuses the standalone Qwen3-VL vision checkpoint the
  identity-edit models already declare (`with_vision = edit or ostris_edit`,
  plus `vision_encoder_filename` / `preload_URLs` in the handler branch), so
  there's no new download for anyone who already runs Krea 2 Edit.
- Reference-image count is capped at 3 (the published LoRAs are trained for
  1–2); refs are plain `I` only — there's no `K` "main subject" concept in this
  scheme — and inpainting is off.
- Ostris's node also has a `kv_cache` toggle for LoRAs trained with cached
  reference K/V. Out of scope here; the published edit LoRAs don't need it.
- Only a Turbo def is included since that's what the public LoRA targets; a raw
  variant would be a defaults file, no code.
