### PR TITLE
feat(minimax_h3): opt-in First-Block Cache for faster H3 generation

### DIFF
--- a/models/minimax_h3/minimax_h3_handler.py
+++ b/models/minimax_h3/minimax_h3_handler.py
@@ -65,6 +65,19 @@ PRUNED_INFOS = """
 The Pruned checkpoint replaces the full AdaLN timestep projection matrices with precomputed low-rank modulation curves. It accepts the same inputs and settings as its 33B counterpart while reducing checkpoint size and weight-transfer cost.
 """
 
+FBC_INFOS = """
+### Steps Skipping (First-Block Cache)
+
+MiniMax H3 supports **First-Block Cache** under Advanced → Steps Skipping:
+
+- Every step still runs DiT block 0.
+- If that block's residual is close to the previous full step, blocks 1–49 are skipped and the previous full residual is reused.
+- Higher acceleration multipliers use a looser threshold (faster, more quality risk).
+- Keep the first ~10% of steps unskipped. Always fully computes the last step.
+- This is approximate: check both **video and audio** quality. Disable it for final/hero gens.
+- Inspired by Sol-Engine FirstBlockCache; clean-room WanGP implementation (not Mag Cache / Tea Cache).
+"""
+
 
 class family_handler:
     @staticmethod
@@ -104,6 +117,15 @@ class family_handler:
         return getattr(args, "lora_dir_minimax_h3", None) or os.path.join(lora_root, "minimax_h3")
 
     @staticmethod
+    def set_cache_parameters(cache_type, base_model_type, model_def, inputs, skip_steps_cache):
+        from .step_cache import configure_h3_cache
+
+        if cache_type == "fbc":
+            configure_h3_cache(skip_steps_cache)
+        else:
+            raise Exception(f"MiniMax H3 does not support cache type {cache_type}")
+
+    @staticmethod
     def query_model_def(base_model_type, model_def):
         reference_mode = base_model_type in (REF2VA_ARCHITECTURE, REF2VA_PRUNED_ARCHITECTURE)
         pruned = base_model_type in (FL2VA_PRUNED_ARCHITECTURE, REF2VA_PRUNED_ARCHITECTURE)
@@ -127,7 +149,8 @@ class family_handler:
             "returns_audio": True,
             "multimedia_generation": True,
             "control_video_trim_disabled": True,
-            "infos": (REF2VA_INFOS if reference_mode else FL2VA_INFOS) + (PRUNED_INFOS if pruned else ""),
+            "first_block_cache": True,
+            "infos": (REF2VA_INFOS if reference_mode else FL2VA_INFOS) + (PRUNED_INFOS if pruned else "") + FBC_INFOS,
             "prompt_infos": REF2VA_PROMPT_INFOS if reference_mode else FL2VA_PROMPT_INFOS,
             "prompt_enhancer_button_label": "Write H3 Prompt",
             "prompt_enhancer_def": {
@@ -353,4 +376,7 @@ class family_handler:
             "audio_prompt_type": "",
             "video_prompt_type": "",
             "image_mode": 0,
+            "skip_steps_cache_type": "",
+            "skip_steps_multiplier": 2.0,
+            "skip_steps_start_step_perc": 10,
         })

--- a/models/minimax_h3/pipeline.py
+++ b/models/minimax_h3/pipeline.py
@@ -369,12 +369,22 @@ class MiniMaxH3Pipeline:
         if sigmas_video.shape != sigmas_audio.shape:
             raise ValueError("The selected H3 flow shift collapses a different number of video and audio schedule points")
         model_steps = sigmas_video.numel() - 1
+        cache = getattr(self.transformer, "cache", None)
+        if cache is not None and getattr(cache, "h3_first_block", False):
+            from .step_cache import finish_h3_cache, reset_h3_cache
+
+            reset_h3_cache(cache, model_steps)
+            thr = float(getattr(cache, "fbc_threshold", 0.08))
+            start = int(getattr(cache, "start_step", 0) or 0)
+            print(f"[H3 FirstBlockCache] enabled threshold={thr:.3f} start_step={start}/{model_steps}", flush=True)
         if callback is not None:
             callback(-1, None, True, override_num_inference_steps=model_steps)
         for step in tqdm(range(model_steps), desc="H3 denoising"):
             self._set_interrupt_state()
             self._check_abort()
             offload.set_step_no_for_lora(self.transformer, step)
+            payload["step_no"] = step
+            payload["num_steps"] = model_steps
             video_velocity, audio_velocity = self.transformer(video, audio, sigmas_video[step:step + 1], sigmas_audio[step:step + 1], context, payload)
             video_sigma_from_t = 1.0 - (1.0 - sigmas_video[step])
             video_ratio = sigmas_video[step + 1] / sigmas_video[step]
@@ -387,6 +397,13 @@ class MiniMaxH3Pipeline:
             video_velocity = audio_velocity = None
             if callback is not None:
                 callback(step, video[0].detach().cpu(), False)
+
+        if cache is not None and getattr(cache, "h3_first_block", False):
+            from .step_cache import finish_h3_cache
+
+            summary = finish_h3_cache(cache)
+            if summary:
+                print(summary, flush=True)
 
         if set_progress_status is not None:
             set_progress_status("Decoding H3 video and stereo audio")

--- a/models/minimax_h3/step_cache.py
+++ b/models/minimax_h3/step_cache.py
@@ -1,0 +1,132 @@
+"""First-Block residual cache for MiniMax H3 (Sol-Engine style, single-GPU).
+
+Runs DiT block 0 every step. If the first-block residual is close enough to the
+previous computed step, reuses the previous full-stack residual and skips blocks
+1..N-1. Always fully computes the warmup head and the final step.
+
+This is an approximation. Prefer conservative thresholds for audio+video quality.
+Inspired by Sol-Engine's FirstBlockCache line and cache-dit FBC; clean-room code
+for WanGP (no Sol-Engine / Spectrum source copied).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Optional
+
+
+# Multiplier (UI "around xN speed up") -> residual relative-L1 threshold.
+# Sol-Engine's published H3 fullopt used 0.08 on multi-GPU; single-GPU starts
+# more conservative because offload and shorter step counts change the curve.
+_MULTIPLIER_THRESHOLDS = (
+    (1.5, 0.05),
+    (1.75, 0.065),
+    (2.0, 0.08),
+    (2.25, 0.10),
+    (2.5, 0.12),
+)
+
+
+def threshold_from_multiplier(multiplier: float) -> float:
+    mult = float(multiplier)
+    if mult <= _MULTIPLIER_THRESHOLDS[0][0]:
+        return _MULTIPLIER_THRESHOLDS[0][1]
+    if mult >= _MULTIPLIER_THRESHOLDS[-1][0]:
+        return _MULTIPLIER_THRESHOLDS[-1][1]
+    for (m0, t0), (m1, t1) in zip(_MULTIPLIER_THRESHOLDS, _MULTIPLIER_THRESHOLDS[1:]):
+        if m0 <= mult <= m1:
+            span = m1 - m0
+            alpha = 0.0 if span <= 0 else (mult - m0) / span
+            return t0 + alpha * (t1 - t0)
+    return 0.08
+
+
+def relative_l1(current, previous) -> float:
+    """Mean |a-b| / mean |b|, matching FirstBlockCache skip metric."""
+    import torch
+
+    prev = previous.detach().float()
+    cur = current.detach().float()
+    denom = prev.abs().mean().clamp_min(1e-8)
+    return float((cur - prev).abs().mean().div(denom).item())
+
+
+def configure_h3_cache(skip_steps_cache: Any) -> dict:
+    """Attach H3 First-Block settings onto WanGP's skip_steps_cache object."""
+    threshold = threshold_from_multiplier(getattr(skip_steps_cache, "multiplier", 2.0))
+    skip_steps_cache.update({
+        "h3_first_block": True,
+        "fbc_threshold": threshold,
+        "cache_type": "fbc",
+    })
+    return {"method": "h3_first_block_cache", "threshold": threshold}
+
+
+def reset_h3_cache(cache: Any, num_steps: int) -> None:
+    if cache is None or not getattr(cache, "h3_first_block", False):
+        return
+    cache.num_steps = int(num_steps)
+    cache.skipped_steps = 0
+    cache.full_steps = 0
+    cache.previous_residual = None
+    cache.previous_modulated_input = None  # stores previous first-block residual
+    cache._denoise_t0 = time.perf_counter()
+    cache._denoise_seconds = None
+
+
+def finish_h3_cache(cache: Any) -> Optional[str]:
+    if cache is None or not getattr(cache, "h3_first_block", False):
+        return None
+    if getattr(cache, "_denoise_t0", None) is not None:
+        cache._denoise_seconds = time.perf_counter() - cache._denoise_t0
+    full = int(getattr(cache, "full_steps", 0) or 0)
+    skipped = int(getattr(cache, "skipped_steps", 0) or 0)
+    total = full + skipped
+    thr = float(getattr(cache, "fbc_threshold", 0.0) or 0.0)
+    seconds = getattr(cache, "_denoise_seconds", None)
+    parts = [
+        f"[H3 FirstBlockCache] steps full={full} skipped_tail={skipped}/{total or 0}",
+        f"threshold={thr:.3f}",
+    ]
+    if seconds is not None:
+        parts.append(f"denoise={seconds:.2f}s")
+    if total > 0 and skipped > 0:
+        parts.append(f"block-stack cut~{100.0 * skipped / total:.0f}% of steps")
+    return " ".join(parts)
+
+
+def should_skip_remaining(
+    cache: Any,
+    step_no: int,
+    first_residual,
+) -> bool:
+    """Return True if blocks after the first may reuse the previous full residual."""
+    if cache is None or not getattr(cache, "h3_first_block", False):
+        return False
+    num_steps = int(getattr(cache, "num_steps", 0) or 0)
+    start_step = int(getattr(cache, "start_step", 0) or 0)
+    if step_no <= start_step:
+        return False
+    if num_steps > 0 and step_no >= num_steps - 1:
+        return False
+    prev_first = getattr(cache, "previous_modulated_input", None)
+    prev_full = getattr(cache, "previous_residual", None)
+    if prev_first is None or prev_full is None:
+        return False
+    if prev_first.shape != first_residual.shape:
+        return False
+    if prev_full.shape != first_residual.shape:
+        return False
+    delta = relative_l1(first_residual, prev_first)
+    cache.last_fbc_delta = delta
+    return delta < float(getattr(cache, "fbc_threshold", 0.08))
+
+
+__all__ = [
+    "configure_h3_cache",
+    "finish_h3_cache",
+    "relative_l1",
+    "reset_h3_cache",
+    "should_skip_remaining",
+    "threshold_from_multiplier",
+]

--- a/models/minimax_h3/transformer.py
+++ b/models/minimax_h3/transformer.py
@@ -458,12 +458,45 @@ class MiniMaxH3Model(nn.Module):
             del positions, frequencies
         del adaln_indices, changes
 
-        for block in self.blocks:
+        cache = getattr(self, "cache", None)
+        use_fbc = cache is not None and getattr(cache, "h3_first_block", False)
+        if use_fbc:
+            from .step_cache import should_skip_remaining
+
+            step_no = int(payload.get("step_no", 0) or 0)
+            # Blocks mutate hidden in-place via gated residuals; clone the pre-block state.
+            original = hidden.detach().clone()
             if self._interrupt:
                 raise GenerationInterrupted
-            h_list = [hidden]
-            hidden = None
-            hidden = block(h_list, temb, segments, rope)
+            hidden = self.blocks[0]([hidden], temb, segments, rope)
+            first_residual = hidden - original
+            if should_skip_remaining(cache, step_no, first_residual):
+                # Reuse previous full-stack residual; first block already ran.
+                prev = cache.previous_residual
+                if prev.device != original.device or prev.dtype != original.dtype:
+                    prev = prev.to(device=original.device, dtype=original.dtype)
+                hidden = original.add(prev)
+                cache.skipped_steps = int(getattr(cache, "skipped_steps", 0) or 0) + 1
+                del first_residual, original
+            else:
+                for block in self.blocks[1:]:
+                    if self._interrupt:
+                        raise GenerationInterrupted
+                    h_list = [hidden]
+                    hidden = None
+                    hidden = block(h_list, temb, segments, rope)
+                # Store residuals for a later skip (detached; no grad graph).
+                cache.previous_residual = (hidden.detach() - original).contiguous()
+                cache.previous_modulated_input = first_residual.detach().contiguous()
+                cache.full_steps = int(getattr(cache, "full_steps", 0) or 0) + 1
+                del first_residual, original
+        else:
+            for block in self.blocks:
+                if self._interrupt:
+                    raise GenerationInterrupted
+                h_list = [hidden]
+                hidden = None
+                hidden = block(h_list, temb, segments, rope)
 
         target_video_rows = latent_t * (latent_h // self.patch_size[1]) * (latent_w // self.patch_size[2])
         target_audio_rows = audio_t * 2

--- a/wgp.py
+++ b/wgp.py
@@ -960,7 +960,7 @@ def validate_settings(state, model_type, single_prompt, inputs, silent=False):
         if int(inputs.get("batch_size", 1) or 1) > image_batch_size_max:
             return err(f"This model supports a maximum of {image_batch_size_max} image{'s' if image_batch_size_max > 1 else ''} per generation.")
     is_edit_mode = str(inputs.get("mode", "") or "").startswith("edit_")
-    any_steps_skipping = model_def.get("tea_cache", False) or model_def.get("mag_cache", False)
+    any_steps_skipping = model_def.get("tea_cache", False) or model_def.get("mag_cache", False) or model_def.get("first_block_cache", False)
     model_type = get_base_model_type(model_type)
 
     model_filename = get_model_filename(model_type)  
@@ -5037,7 +5037,12 @@ def select_media(state, current_gallery_tab, input_file_list, file_selected, aud
             video_skip_steps_multiplier = configs.get("skip_steps_multiplier", 0)
             video_skip_steps_cache_start_step_perc = configs.get("skip_steps_start_step_perc", 0)
             if len(video_skip_steps_cache_type) > 0:
-                video_skip_steps_cache = "TeaCache" if video_skip_steps_cache_type == "tea" else "MagCache"
+                if video_skip_steps_cache_type == "tea":
+                    video_skip_steps_cache = "TeaCache"
+                elif video_skip_steps_cache_type == "fbc":
+                    video_skip_steps_cache = "FirstBlockCache"
+                else:
+                    video_skip_steps_cache = "MagCache"
                 video_skip_steps_cache += f" x{video_skip_steps_multiplier }"
                 if video_skip_steps_cache_start_step_perc >0:  video_skip_steps_cache += f", Start from {video_skip_steps_cache_start_step_perc}%"
                 values += [ video_skip_steps_cache ]
@@ -6889,6 +6894,8 @@ def generate_media(
         elif skip_steps_cache_type == "tea":
             def_tea_coefficients = model_def.get("teacache_coefficients", None) if model_def != None else None
             if def_tea_coefficients is not None: skip_steps_cache.coefficients = def_tea_coefficients
+        elif skip_steps_cache_type == "fbc":
+            pass  # First-Block Cache parameters set by model_handler.set_cache_parameters
         else:
             raise Exception(f"unknown cache type {skip_steps_cache_type}")
     trans.cache = skip_steps_cache
@@ -9265,7 +9272,7 @@ def prepare_inputs_dict(target, inputs, model_type = None, model_filename = None
         pop += ["alt_scale"]
 
 
-    if not (model_def.get("tea_cache", False) or model_def.get("mag_cache", False)) :
+    if not (model_def.get("tea_cache", False) or model_def.get("mag_cache", False) or model_def.get("first_block_cache", False)) :
         pop += ["skip_steps_cache_type", "skip_steps_multiplier", "skip_steps_start_step_perc"]
 
     guidance_max_phases = model_def.get("guidance_max_phases", 0)
@@ -11118,6 +11125,7 @@ def generate_media_tab(update_form = False, state_dict = None, ui_defaults = Non
             lock_inference_steps = model_def.get("lock_inference_steps", False) or (audio_only and not inference_steps_enabled)
             any_tea_cache = model_def.get("tea_cache", False)
             any_mag_cache = model_def.get("mag_cache", False)
+            any_first_block_cache = model_def.get("first_block_cache", False)
             recammaster = base_model_type in ["recam_1.3B"]
             vace = test_vace_module(base_model_type)
             multitalk = model_def.get("multitalk_class", False)
@@ -11901,16 +11909,17 @@ def generate_media_tab(update_form = False, state_dict = None, ui_defaults = Non
                             search_empty_label="No matching LoRAs",
                         )
                         loras_multipliers = gr.Textbox(label="LoRAs Multipliers (1.0 by default) separated by Space chars or CR, lines that start with # are ignored", value=launch_multis_str)
-                with gr.Tab("Steps Skipping", visible = any_tea_cache or any_mag_cache) as speed_tab:
+                with gr.Tab("Steps Skipping", visible = any_tea_cache or any_mag_cache or any_first_block_cache) as speed_tab:
                     with gr.Column():
-                        gr.Markdown("<B>Tea Cache and Mag Cache accelerate the Video Generation by skipping intelligently some steps, the more steps are skipped the lower the quality of the video.</B>")
-                        gr.Markdown("<B>Steps Skipping  consumes also VRAM. It is recommended not to skip at least the first 10% steps.</B>")
+                        gr.Markdown("<B>Tea Cache, Mag Cache and First-Block Cache accelerate generation by skipping work on some steps. More skipping usually means lower quality.</B>")
+                        gr.Markdown("<B>Steps Skipping also consumes VRAM. It is recommended not to skip at least the first 10% steps. First-Block Cache is for MiniMax H3 (joint video+audio): check audio quality too.</B>")
                         steps_skipping_choices = [("None", "")]
                         if any_tea_cache: steps_skipping_choices += [("Tea Cache", "tea")]
                         if any_mag_cache: steps_skipping_choices += [("Mag Cache", "mag")]
+                        if any_first_block_cache: steps_skipping_choices += [("First-Block Cache", "fbc")]
                         skip_steps_cache_type = gr.Dropdown(
                             choices= steps_skipping_choices,
-                            value="" if not (any_tea_cache or any_mag_cache) else ui_get("skip_steps_cache_type"),
+                            value="" if not (any_tea_cache or any_mag_cache or any_first_block_cache) else ui_get("skip_steps_cache_type"),
                             visible=True,
                             label="Skip Steps Cache Type"
                         )


### PR DESCRIPTION
## Summary

Adds an **opt-in First-Block Cache** accelerator for **MiniMax H3** (FL2VA / Ref2VA, full + pruned).

This is **not** Mag Cache or Tea Cache. It is a separate Steps Skipping option labeled **First-Block Cache** (`fbc`).

On a consumer single-GPU run (RTX 4080 SUPER), a same-settings A/B went roughly **521s → 291s (~1.8×)** with acceleration ×2.0 and ~10% warmup. Gains depend on resolution, steps, offload profile, and threshold.

## Motivation

MiniMax H3 is expensive on “GPU poor” setups. NVIDIA Sol-Engine’s H3 line shows that **FirstBlockCache** is the largest *portable* approximation win (their published stack also includes multi-GPU CP, kernel fusion, and Sol-Attn — those are **not** in this PR).

Sol-Attn was evaluated and intentionally **not** included: released kernels target SM90/SM100-class GPUs and a multi-GPU Ulysses path, which does not match typical WanGP single-GPU + MMGP offload users.

## What it does

For each denoise step when First-Block Cache is enabled:

1. Always run **DiT block 0**
2. Compare first-block residual vs previous full step (relative L1)
3. If below threshold → skip blocks **1..N-1** and reuse previous full residual
4. Else → run remaining blocks and store residuals
5. Always fully compute the **warmup head** (start %) and the **last step**

UI acceleration multipliers map to residual thresholds (conservative → aggressive):

| Multiplier | Threshold |
|---|---|
| ×1.5 | 0.05 |
| ×2.0 | 0.08 (Sol-Engine-style default ballpark) |
| ×2.5 | 0.12 |

## UI / UX

- Advanced → **Steps Skipping**
- **Skip Steps Cache Type → First-Block Cache** (value `fbc`)
- Default remains **None** (no behavior change unless enabled)
- History label: `FirstBlockCache x…`
- Model info blurb documents quality caveats (video **and** audio)

Terminal logs for A/B:

```text
[H3 FirstBlockCache] enabled threshold=0.080 start_step=…
[H3 FirstBlockCache] steps full=… skipped_tail=… denoise=….s …
```

## Files

| File | Change |
|---|---|
| `models/minimax_h3/step_cache.py` | **New** — threshold map, skip decision, timing summary |
| `models/minimax_h3/transformer.py` | First-block residual path in `MiniMaxH3Model.forward` |
| `models/minimax_h3/pipeline.py` | Cache reset, `step_no` payload, summary print |
| `models/minimax_h3/minimax_h3_handler.py` | `first_block_cache: True`, `set_cache_parameters`, docs/defaults |
| `wgp.py` | Wire `first_block_cache` / `fbc` into Steps Skipping UI + history |

## What this is *not*

- Not Mag Cache / Tea Cache math
- Not Sol-Attn / Sol-Engine runtime / multi-GPU Ulysses
- Not Spectrum feature forecasting (possible follow-up)
- Not a silent default quality change

Clean-room implementation inspired by Sol-Engine FirstBlockCache / cache-dit FBC ideas. No Sol-Engine or ComfyUI-Spectrum source was copied.

## How to test

1. Load MiniMax H3 (e.g. FL2VA)
2. Fixed prompt + seed + steps (e.g. 20) + resolution
3. **A:** Steps Skipping = None → note time
4. **B:** First-Block Cache, ×2.0, start ~10% → note time + terminal skip stats
5. Compare **video and audio** (joint model — dialogue can degrade while frames look OK)
6. For hero/final gens, leave cache off or use ×1.5

## Quality notes

This is an **approximation**. Higher multipliers skip more and risk more drift, especially audio/lip sync. Recommend:

- ×1.5–×2.0 for drafts
- Off for final renders
- Always check soundtrack, not only frames

## Checklist

- [x] Opt-in only (default off)
- [x] Proper UI name: **First-Block Cache** (`fbc`), not Mag Cache
- [x] Warmup + last step always full
- [x] Timing / skip logs for measurement
- [x] Local A/B shows meaningful speedup
- [ ] Maintainer review of quality on FL2VA + Ref2VA
- [ ] Optional: more threshold tuning after community feedback

Thanks for WanGP — happy to adjust naming, thresholds, or defaults if you prefer different knobs.