### PR TITLE
fix: NVFP4/AWQ text encoder dequantization and AWQ pre_quant_scale injection

### DIFF
--- a/models/minimax_h3/minimax_h3_main.py
+++ b/models/minimax_h3/minimax_h3_main.py
@@ -45,7 +45,24 @@ def _strip_wrappers(state_dict, quantization_map=None, tied_weights_map=None):
 
 
 def _strip_text_encoder_wrapper(state_dict, quantization_map=None, tied_weights_map=None):
-    root = "language_model" if "model.embed_tokens.weight" in state_dict else ""
+    # Strip Comfy quantization metadata markers
+    keys_to_remove = [k for k in list(state_dict.keys()) if k.endswith(".comfy_quant")]
+    for k in keys_to_remove:
+        del state_dict[k]
+
+    # Dequantize INT8 embedding to BF16 so MMGP sees consistent dtypes
+    embed_weight_key = "model.embed_tokens.weight"
+    embed_scale_key = "model.embed_tokens.weight_scale"
+    if embed_weight_key in state_dict and embed_scale_key in state_dict:
+        w = state_dict[embed_weight_key]
+        s = state_dict[embed_scale_key]
+        if w.dtype == torch.int8:
+            dequant = w.to(torch.float32) * s.to(torch.float32)
+            state_dict[embed_weight_key] = dequant.to(torch.bfloat16)
+            del state_dict[embed_scale_key]
+            print("[H3 FIX] Dequantized INT8 embedding to BF16")
+
+    root = "language_model" if embed_weight_key in state_dict else ""
     return tuple(offload.map_state_dict([state_dict, quantization_map, tied_weights_map], rules={"model": root}))
 
 
@@ -100,6 +117,41 @@ def _load_text_encoder(filename, dtype):
     offload.load_model_data(text_encoder, filename, writable_tensors=False, default_dtype=dtype,
                             preprocess_sd=_strip_text_encoder_wrapper, ignore_unused_weights=True)
     text_encoder.set_tokenizer(os.path.dirname(config_path))
+
+    # Fix AWQ pre_quant_scale: load directly from checkpoint since MMGP strips them.
+    # Map checkpoint key prefix "model." → module path "language_model."
+    import safetensors.torch as _st
+    _awq_count = 0
+    try:
+        with _st.safe_open(filename, framework="pt", device="cpu") as _sf:
+            for _key in _sf.keys():
+                if ".pre_quant_scale" in _key and _key.startswith("model."):
+                    # Convert "model.layers.N.mlp.down_proj.pre_quant_scale"
+                    # to "language_model.layers.N.mlp.down_proj"
+                    _mod_path = "language_model" + _key[len("model"):_key.rfind(".pre_quant_scale")]
+                    _parts = _mod_path.split(".")
+                    _mod = text_encoder
+                    for _p in _parts:
+                        if _p.isdigit():
+                            _mod = _mod[int(_p)]
+                        else:
+                            _mod = getattr(_mod, _p)
+                    _scale = _sf.get_tensor(_key).to(dtype=dtype)
+                    # Register as buffer and monkey-patch forward
+                    if hasattr(_mod, "forward"):
+                        _mod.register_buffer("pre_quant_scale", _scale, persistent=False)
+                        _orig_fwd = _mod.forward
+                        def _make_awq_fwd(orig, pqs):
+                            def awq_forward(input):
+                                scaled = input * pqs.to(device=input.device, dtype=input.dtype)
+                                return orig(scaled)
+                            return awq_forward
+                        _mod.forward = _make_awq_fwd(_orig_fwd, _scale)
+                        _awq_count += 1
+    except Exception as _e:
+        print(f"[H3 FIX] Warning: could not load AWQ scales: {_e}")
+    print(f"[H3 FIX] Patched {_awq_count} AWQ linears with pre_quant_scale from checkpoint")
+
     text_encoder.eval().requires_grad_(False)
     return text_encoder
 


### PR DESCRIPTION
## Problem

FL2VA/T2V text conditioning produces prompt-unrelated output (wrong language, garbled speech) when using NVFP4/AWQ quantized Qwen3-VL text encoder checkpoints. Reported in #2066.

## Root Causes

Three issues in `_load_text_encoder` / `_strip_text_encoder_wrapper`:

1. **INT8 embedding not dequantized** — The NVFP4/AWQ checkpoint stores embeddings as INT8 weights with per-row FP32 scales. WanGP loaded them raw without applying row-scaled dequantization, producing incorrect embeddings and triggering MMGP dtype assertion failures (`assert model_dtype == dtype`).

2. **AWQ pre_quant_scale ignored** — The checkpoint contains `pre_quant_scale` tensors for 100 linear layers (down_proj + o_proj per layer). Quanto's `QLinearQuantoRouter` loads these as buffers but **never applies them in forward()**, silently discarding the AWQ input smoothing calibration. This is the primary cause of degraded text conditioning quality.

3. **comfy_quant metadata markers** — The checkpoint contains `.comfy_quant` keys that MMGP cannot handle during state dict loading.

## Fix

### In `_strip_text_encoder_wrapper`:
- Strip `.comfy_quant` metadata markers from state dict
- Detect INT8 embedding weights and dequantize to BF16 using row scales before MMGP profiling sees them

### After `offload.load_model_data`:
- Read all `pre_quant_scale` tensors directly from the safetensors checkpoint file (since MMGP strips them during loading)
- Map checkpoint key prefix `model.` → module path `language_model.`
- Register each scale as a buffer and monkey-patch the module's forward to apply input smoothing: `input * scale` before the linear operation

## Testing

Tested with seed 424246, flow_shift=12, profile 3, SDPA attention on RTX 3090:
- Before fix: prompt-unrelated audio output
- After fix: output matches Maestro reference generation exactly
- Performance: ~6m 39s (vs Maestro's ~25m 31s on same hardware)

## Files Changed

- `models/minimax_h3/minimax_h3_main.py` — 53 lines added to `_strip_text_encoder_wrapper` and `_load_text_encoder`