### PR TITLE
Bound SessionStream queue, skip unused preview builds, slide off a busy port

### DIFF
--- a/shared/api.py
+++ b/shared/api.py
@@ -226,21 +226,73 @@ def store_api_output_artifact(gen: dict[str, Any], client_id: str, video_path: A
 
 
 class SessionStream:
+    # Events that must never be shed under back-pressure — dropping them would
+    # lose results; everything else is a transient UI update.
+    _NEVER_DROP_KINDS = ("output", "result", "error", "completed")
+    # Stale progress/preview updates are the first candidates for eviction.
+    _DROP_FIRST_KINDS = ("progress", "preview")
+
     def __init__(self) -> None:
-        self._queue: queue.Queue[SessionEvent | object] = queue.Queue()
+        # Bounded so undrained streams (fire-and-forget consumers that only call
+        # job.result()) cannot grow without limit; drained consumers never hit it.
+        self._queue: queue.Queue[SessionEvent | object] = queue.Queue(maxsize=256)
         self._closed = threading.Event()
         self._sentinel = object()
+
+    def _drop_oldest_droppable(self) -> bool:
+        # Evict the oldest progress/preview event first, then any other
+        # non-critical event; never touch _NEVER_DROP_KINDS or the sentinel.
+        with self._queue.mutex:
+            items = self._queue.queue
+            for restrict in (self._DROP_FIRST_KINDS, None):
+                for index, item in enumerate(items):
+                    kind = getattr(item, "kind", None)
+                    if item is self._sentinel or kind in self._NEVER_DROP_KINDS:
+                        continue
+                    if restrict is not None and kind not in restrict:
+                        continue
+                    del items[index]
+                    self._queue.not_full.notify()
+                    return True
+        return False
+
+    def _force_append(self, item: Any) -> None:
+        # Last resort for must-deliver items when the queue holds only other
+        # must-keep events: grow past maxsize rather than block or drop.
+        with self._queue.mutex:
+            self._queue.queue.append(item)
+            self._queue.unfinished_tasks += 1
+            self._queue.not_empty.notify()
 
     def put(self, kind: str, data: Any = None) -> None:
         if self._closed.is_set():
             return
-        self._queue.put(SessionEvent(kind=kind, data=data))
+        event = SessionEvent(kind=kind, data=data)
+        while True:
+            try:
+                self._queue.put_nowait(event)
+                return
+            except queue.Full:
+                if self._drop_oldest_droppable():
+                    continue
+                if kind in self._NEVER_DROP_KINDS:
+                    self._force_append(event)
+                return
 
     def close(self) -> None:
         if self._closed.is_set():
             return
         self._closed.set()
-        self._queue.put(self._sentinel)
+        try:
+            self._queue.put_nowait(self._sentinel)
+        except queue.Full:
+            if self._drop_oldest_droppable():
+                try:
+                    self._queue.put_nowait(self._sentinel)
+                    return
+                except queue.Full:
+                    pass
+            self._force_append(self._sentinel)
 
     def clear(self) -> None:
         while True:

--- a/shared/api_cli.py
+++ b/shared/api_cli.py
@@ -67,7 +67,7 @@ def run_cli_job(session, job: SessionJob, tasks: list[dict[str, Any]]) -> None:
                 if item is None:
                     if worker_done.is_set() and not worker_thread.is_alive():
                         break
-                    time.sleep(0.01)
+                    time.sleep(0.05)
                     continue
                 command, data = item
                 if command == "worker_exit":
@@ -197,6 +197,12 @@ def _handle_command(session, job: SessionJob, wgp, tasks: list[dict[str, Any]], 
         session._emit_callback("on_progress", progress, job=job)
         return
     if command == "preview":
+        callback = job._callbacks if job._callbacks is not None else session._callbacks
+        # Preview images are expensive to build; skip them entirely when the
+        # callbacks object consumes neither previews nor raw events. A session
+        # without callbacks keeps them so events-queue consumers still see them.
+        if callback is not None and not (hasattr(callback, "on_preview") or hasattr(callback, "on_event")):
+            return
         preview = session._build_preview_update(wgp, tasks, data)
         if preview is not None:
             job.events.put("preview", preview)

--- a/wgp.py
+++ b/wgp.py
@@ -13580,6 +13580,20 @@ if __name__ == "__main__":
     server_port = int(args.server_port)
     if server_port == 0:
         server_port = int(os.getenv("SERVER_PORT", "7860"))
+    # The requested port can be squatted (e.g. a stale launcher proxy) — slide to
+    # the next free one instead of crashing; the launcher reads the real URL from
+    # the Gradio banner.
+    import socket as _socket
+    for _p in range(server_port, server_port + 50):
+        try:
+            with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as _s:
+                _s.bind(("127.0.0.1", _p))
+            if _p != server_port:
+                print(f"Port {server_port} is busy — using {_p} instead.")
+            server_port = _p
+            break
+        except OSError:
+            continue
     server_name = args.server_name
     if args.listen:
         server_name = "0.0.0.0"


### PR DESCRIPTION
Three small, independent fixes found while driving the session API (`WanGPSession.submit_task`) from a long-running local integration. Each is isolated to its own concern; happy to split them into separate PRs if you'd prefer.

## 1. `shared/api.py` — bound the `SessionStream` queue

`SessionStream` used an unbounded `queue.Queue`. Any consumer that submits a task and only calls `job.result()` — never draining `job.events` — leaves progress and preview events accumulating for the entire generation, so the queue grows without limit. On long sliding-window video jobs that is a lot of retained objects.

This caps the queue at 256 and sheds load when full:

- Oldest **stale `progress`/`preview`** events are evicted first, then any other non-critical event.
- **`output`, `result`, `error`, `completed` are never evicted** — losing one would lose the generation's result.
- If the queue contains *only* must-keep events, the incoming must-keep item is appended past `maxsize` rather than blocking the producer or being dropped.
- `close()` follows the same rule, so the sentinel is always delivered and a consumer can never hang waiting for termination.

Drained consumers never reach the cap, so existing behaviour is unchanged for them.

## 2. `shared/api_cli.py` — don't build previews nothing consumes

`_build_preview_update` ran on every `preview` command even when the caller had no interest in previews. Skipped when the callbacks object exposes neither `on_preview` nor `on_event`. A session with no callbacks at all keeps building them, so events-queue consumers are unaffected. Idle poll also relaxed from 10 ms to 50 ms.

## 3. `wgp.py` — slide off a busy port instead of aborting

If the requested server port is already held (commonly a stale launcher proxy), startup fails. This probes up to 50 ports from the requested one and binds the first free one, printing the substitution. Launchers already read the real URL from the Gradio banner, so nothing downstream needs to change.

## Testing

Verified against this branch (i.e. post-merge with current `main`, not just my older checkout):

- All three files compile.
- A behavioural test for `SessionStream` covering: queue stays bounded under a 5,000-event flood; `output`/`error`/`result` all survive that flood with payloads intact; 400 consecutive critical events are never evicted; `close()` does not block on a saturated queue; the consumer always reaches termination; `put()` after `close()` is a no-op. All pass.

Note the port-sliding change in (3) is the least generic of the three — it's most useful behind a launcher that assigns ports. Drop that hunk if it doesn't fit upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)