### PR TITLE
Clamp dropdown values to choices; fix missing Prompt Enhancer button

### DIFF
--- a/wgp.py
+++ b/wgp.py
@@ -81,7 +81,7 @@ from shared.utils.process_locks import (
 from shared.utils.model_unload import model_unload_guard, wait_for_model_unload
 from shared.deepy.config import get_deepy_default_runtime_config, set_deepy_runtime_config
 from shared.loras_migration import migrate_loras_layout
-from shared.utils.wgp_config_migration import migrate_extension_defaults
+from shared.utils.wgp_config_migration import migrate_extension_defaults, get_prompt_enhancer_default_mode
 from shared.utils import files_locator as fl 
 from shared.gradio.audio_gallery import AudioGallery  
 from shared.utils.self_refiner import normalize_self_refiner_plan, ensure_refiner_list, add_refiner_rule, remove_refiner_rule
@@ -11616,7 +11616,7 @@ def generate_media_tab(update_form = False, state_dict = None, ui_defaults = Non
                 wizard_prompt = gr.Textbox(visible=not advanced_prompt, label=wizard_prompt_label, value=default_wizard_prompt, lines=3, elem_id=PROMPT_WIZARD_ELEM_ID)
                 wizard_prompt_activated_var = gr.Text(wizard_prompt_activated, visible= False)
                 wizard_variables_var = gr.Text(wizard_variables, visible = False)
-            with gr.Row(visible= server_config.get("enhancer_enabled", 0) > 0  ) as prompt_enhancer_row:
+            with gr.Row(visible= server_config.get("enhancer_enabled", get_prompt_enhancer_default_mode()) > 0  ) as prompt_enhancer_row:
                 on_demand_prompt_enhancer = server_config.get("enhancer_mode", 1) == 1
                 prompt_enhancer_value = str(ui_get("prompt_enhancer") or "")
                 prompt_enhancer_btn_label = str(model_def.get("prompt_enhancer_button_label", "Enhance Prompt"))
@@ -11641,7 +11641,7 @@ def generate_media_tab(update_form = False, state_dict = None, ui_defaults = Non
                     else:
                         prompt_enhancer_mode_value = prompt_enhancer_values[0]
 
-                prompt_enhancer_think_visible = server_config.get("enhancer_enabled", 0) in (3, 4)
+                prompt_enhancer_think_visible = server_config.get("enhancer_enabled", get_prompt_enhancer_default_mode()) in (3, 4)
                 prompt_enhancer_think_value = prompt_enhancer_think_visible and "K" in prompt_enhancer_value and len(prompt_enhancer_mode_value) > 0
                 prompt_enhancer_value = build_prompt_enhancer_value(prompt_enhancer_mode_value, prompt_enhancer_think_value)
                 prompt_enhancer_think_classes = "cbx_centered" if on_demand_prompt_enhancer else "cbx_bottom"

--- a/wgp.py
+++ b/wgp.py
@@ -11617,7 +11617,7 @@ def generate_media_tab(update_form = False, state_dict = None, ui_defaults = Non
                 wizard_prompt_activated_var = gr.Text(wizard_prompt_activated, visible= False)
                 wizard_variables_var = gr.Text(wizard_variables, visible = False)
             with gr.Row(visible= server_config.get("enhancer_enabled", 0) > 0  ) as prompt_enhancer_row:
-                on_demand_prompt_enhancer = server_config.get("enhancer_mode", 0) == 1
+                on_demand_prompt_enhancer = server_config.get("enhancer_mode", 1) == 1
                 prompt_enhancer_value = str(ui_get("prompt_enhancer") or "")
                 prompt_enhancer_btn_label = str(model_def.get("prompt_enhancer_button_label", "Enhance Prompt"))
                 prompt_enhancer_btn = gr.Button( value =prompt_enhancer_btn_label, visible= on_demand_prompt_enhancer, size="lg", scale=1, elem_classes="btn_centered")
@@ -11880,11 +11880,9 @@ def generate_media_tab(update_form = False, state_dict = None, ui_defaults = Non
                                 NAG_alpha = setting_slider("NAG_alpha", visible=True)
                         with gr.Row():
                             repeat_generation = gr.Slider(1, 25.0, value=ui_get("repeat_generation"), step=1, label=f"Num. of Generated {'Audio Files' if audio_only else 'Videos'} per Prompt", visible = not image_outputs, show_reset_button= False) 
-                            multi_images_gen_type = gr.Dropdown( value=ui_get("multi_images_gen_type"), 
-                                choices=[
-                                    ("Generate every combination of images and texts", 0),
-                                    ("Match images and text prompts", 1),
-                                ], visible=multiple_images_as_text_prompts and not edit_mode, label= "Multiple Images as Texts Prompts"
+                            multi_images_gen_choices = [("Generate every combination of images and texts", 0), ("Match images and text prompts", 1)]
+                            multi_images_gen_type = gr.Dropdown( value=get_default_value(multi_images_gen_choices, ui_get("multi_images_gen_type"), 0), 
+                                choices=multi_images_gen_choices, visible=multiple_images_as_text_prompts and not edit_mode, label= "Multiple Images as Texts Prompts"
                             )
                         with gr.Row():
                             multi_prompts_gen_choices = prompt_parser.get_multi_prompts_gen_choices(medium, include_sliding_window=sliding_window_enabled)
@@ -12026,7 +12024,7 @@ def generate_media_tab(update_form = False, state_dict = None, ui_defaults = Non
                                     ("OFF", 0),
                                     ("ON", 1), 
                                 ],
-                                value=ui_get("apg_switch"),
+                                value=get_default_value([("OFF", 0), ("ON", 1)], ui_get("apg_switch"), 0),
                                 visible=True,
                                 scale = 1,
                                 label="Adaptive Projected Guidance (requires Guidance > 1 or Audio Guidance > 1) " if multitalk else "Adaptive Projected Guidance (requires Guidance > 1)",
@@ -12039,7 +12037,7 @@ def generate_media_tab(update_form = False, state_dict = None, ui_defaults = Non
                                     ("OFF", 0),
                                     ("ON", 1), 
                                 ],
-                                value=ui_get("cfg_star_switch"),
+                                value=get_default_value([("OFF", 0), ("ON", 1)], ui_get("cfg_star_switch"), 0),
                                 visible=True,
                                 scale = 1,
                                 label="Classifier-Free Guidance Star (requires Guidance > 1)"


### PR DESCRIPTION
## What

Three `gr.Dropdown` components read saved settings raw via `ui_get()` without validating the value against their current choices, and two inconsistent defaults hide the Prompt Enhancer UI (button + whole row).

## The bug (saving settings is bricked)

`multi_images_gen_type`, `apg_switch` and `cfg_star_switch` all have choices with values `[0, 1]` but take their value straight from `ui_get(...)`:

```python
apg_switch = gr.Dropdown(
    choices=[("OFF", 0), ("ON", 1)],
    value=ui_get("apg_switch"),   # <-- no clamping
    ...
)
```

When a saved `*_settings.json` contains a stale value (e.g. `2` — carried over from an older Wan2GP version, an imported settings file, or a model switch where the choice list differed), gradio raises:

```
gradio.exceptions.Error: 'Value: 2 is not in the list of choices: [0, 1]'
```

...on **any** settings submission from the configuration tab, so the user can no longer save anything. Users also see the startup warning `The value passed into gr.Dropdown() is not in the list of choices...`. Confirmed in the wild (desktop launcher reports), and reproducible by putting `"apg_switch": 2` into `models/_settings.json`.

`perturbation_switch` already does the right thing by clamping with `get_default_value()` — this PR applies the same pattern to the other three 0/1 dropdowns so a stale value falls back to `0` (OFF) instead of crashing the form.

## The enhancer UI bugs

1. **Missing button:** `on_demand_prompt_enhancer` defaulted `enhancer_mode` to `0` (Automatic) at UI build time while the configuration plugin (`plugins/configuration/plugin.py`) and the generation path both default it to `1` (On-Demand Button). With `enhancer_mode` absent from `wgp_config.json`, the "Enhance Prompt" button is invisible even though the dropdown is present — users only get the button back after re-saving the setting (reported as "the Write button is not a button, just a label", since the model's `prompt_enhancer_button_label` is reused as the dropdown label in Automatic mode).
2. **Hidden row:** the enhancer row itself gated on `server_config.get("enhancer_enabled", 0)`, while the Configuration plugin defaults `enhancer_enabled` to `get_prompt_enhancer_default_mode()` (3 on ≥10GB VRAM, else 1). On a fresh install with no `enhancer_enabled` key, the entire enhancer row was hidden even though the plugin shows the feature as enabled.

## Changes

- `wgp.py`: clamp `multi_images_gen_type`, `apg_switch`, `cfg_star_switch` values via `get_default_value(choices, ui_get(...), 0)`
- `wgp.py`: default `enhancer_mode` to `1` (On-Demand Button) for `on_demand_prompt_enhancer`
- `wgp.py`: default the enhancer row visibility and the "Think" checkbox to `get_prompt_enhancer_default_mode()` (matches the Configuration plugin)

## Test

- `python -m py_compile wgp.py` passes.
- With `"apg_switch": 2` in `models/_settings.json`, the dropdown now initializes to `OFF` and settings save cleanly instead of raising the gradio error.
- With no enhancer keys in `wgp_config.json`, the enhancer row + On-Demand button now appear on load.
