### PR TITLE
Robust console output to non-ASCII (fix 'charmap' UnicodeEncodeError crashes)

### DIFF
--- a/wgp.py
+++ b/wgp.py
@@ -1,5 +1,21 @@
 ############# WanGP Copyright DeepBeepMeep 2025-2026 #############
 import os, sys
+# Never crash when printing non-ASCII: Windows consoles/pipes default to the
+# locale codepage (cp1252), so any output containing e.g. a non-Latin filename
+# raises "UnicodeEncodeError: 'charmap' codec can't encode characters". That
+# crash masks the real error and even breaks the error-queue autosave. Setting
+# errors="replace" makes writes always succeed (non-ASCII becomes '?'), while
+# PYTHONUTF8=1 (set by launchers/Pinokio) keeps full fidelity.
+if hasattr(sys.stdout, "reconfigure"):
+    try:
+        sys.stdout.reconfigure(errors="replace")
+    except Exception:
+        pass
+if hasattr(sys.stderr, "reconfigure"):
+    try:
+        sys.stderr.reconfigure(errors="replace")
+    except Exception:
+        pass
 os.environ["GRADIO_LANG"] = "en"
 p = os.path.dirname(os.path.abspath(__file__))
 if p not in sys.path:


### PR DESCRIPTION
## What

Make console output robust to non-ASCII characters so generation errors surface instead of being masked by an encoding crash.

## The bug

On Windows, `sys.stdout`/`sys.stderr` default to the locale codepage (cp1252) when the process is launched with piped stdio — which is exactly how launchers (Wan2GP Desktop, Pinokio) start the server. Any `print()` containing a non-Latin character (a non-ASCII filename, or an error message containing one) raises:

```
UnicodeEncodeError: 'charmap' codec can't encode characters in position 18-19: character maps to <undefined>
```

The crash commonly fires **inside the queue worker's exception handler** (`print('\n'.join(tb))` in `wgp.py`), so:

1. the original generation error is lost — the UI only ever shows the encoding crash, and
2. the error-queue autosave path gets confused (reporter's log shows the charmap error adjacent to the "Error Queue autosaved" message).

Reported from the wild (Wan2GP Desktop issue: Windows server crash with `'charmap' codec` right before error-queue autosave).

## Fix

At the very top of `wgp.py`, reconfigure both streams with `errors="replace"`:

```python
if hasattr(sys.stdout, "reconfigure"):
    try:
        sys.stdout.reconfigure(errors="replace")
    except Exception:
        pass
```

- Writes always succeed — non-ASCII degrades to `?` on legacy cp1252 consoles instead of raising.
- Launchers that already force `PYTHONUTF8=1` (UTF-8 mode) keep full fidelity; the reconfigure only relaxes the error handler, not the encoding.
- The real error now prints and reaches the UI/error-queue unchanged.

## Test

- `python -m py_compile wgp.py` passes.
- Under a cp1252 pipe (`python wgp.py ... | cat`-style stdio on Windows), a `print("生成失败")`-style non-ASCII line no longer raises.
