### PR TITLE
fix(z-image): cast latents to VAE dtype before decode (BFloat16/Half conv2d crash)

### DIFF
--- a/models/z_image/pipeline_z_image.py
+++ b/models/z_image/pipeline_z_image.py
@@ -981,7 +981,7 @@ class ZImagePipeline(DiffusionPipeline, FromSingleFileMixin):
         else:
             latents = (latents / self.vae.config.scaling_factor) + self.vae.config.shift_factor
 
-            image = self.vae.decode(latents, return_dict=False)[0]
+            image = self.vae.decode(latents.to(self.vae.dtype), return_dict=False)[0]
             if vae_upsampler is not None:
                 if vae_upsampler_progress_callback is not None:
                     vae_upsampler_progress_callback("VAE")


### PR DESCRIPTION
## Problem

Z-Image generation crashes in the VAE decode step right after sampling starts:

```
RuntimeError: Input type (struct c10::BFloat16) and bias type (struct c10::Half) should be the same
```

The traceback goes through `pipeline_z_image.py:984` (`image = self.vae.decode(latents, return_dict=False)[0]`) and fails inside the VAE decoder's first conv layer.

## Root cause

The pipeline casts `latents` to the **transformer/text-encoder** dtype at the end of sampling (`pipeline_z_image.py:978` → `latents = latents.to(dtype)`), which is bf16 for quanto bf16 models. However, the VAE is loaded at a **different** dtype: `wgp.py` passes `VAE_dtype = torch.float16 if server_config.get("vae_precision","16") == "16" else torch.float` (fp16 by default, fp32 when set to 32-bit).

`F.conv2d` requires input, weight and bias to share a single dtype, so bf16 latents fed into an fp16 (or fp32) VAE crash. Verified that the `vae_precision="32"` setting does NOT work around this — fp32 VAE + bf16 latents fails identically.

## Fix

Cast latents to the VAE's own dtype at the decode boundary:

```python
image = self.vae.decode(latents.to(self.vae.dtype), return_dict=False)[0]
```

This matches the file's existing convention — the control-image encode path already casts to `self.vae.dtype` (`control_image_tensor.to(device=device, dtype=self.vae.dtype)`). The fix is independent of `vae_precision`, so the user's precision setting keeps working as intended (fp16 for speed / fp32 for sliding-window quality).

## Verification (GPU, with the exact mmgp load path)

- **Unpatched** (default `vae_precision=16`, fp16 VAE + bf16 latents): reproduces the exact reported error.
- **Patched**: `latents.to(self.vae.dtype)` → decode succeeds (`(1, 3, 256, 256)`).
- Also confirmed the launcher-side workaround (loading the VAE as bf16, the checkpoint's native precision) resolves it too — but this pipeline-side cast fixes the root cause for every `vae_precision` value.
