### PR TITLE
fix: keep startup alive when gradio's localhost probe times out on large UIs

### DIFF
--- a/wgp.py
+++ b/wgp.py
@@ -13681,6 +13681,59 @@ if __name__ == "__main__":
         else:
             url = "http://" + server_name
         webbrowser.open(url + ":" + str(server_port), new = 0, autoraise = True)
+
+    def patch_gradio_localhost_probe():
+        """Keep launch() from aborting with "When localhost is not accessible, a
+        shareable link must be created" on large UIs.
+
+        Gradio's launch() probes HEAD / with httpx.head(timeout=3), 5 tries, and
+        aborts when all fail. But serving "/" deep-copies the whole Blocks config
+        and filters components per page with an O(N^2) list-membership test, so
+        first-response time grows super-linearly with component count: on a fast
+        box ~8k components answer in 0.3s, ~32k need >3s and launch() dies even
+        though the server is healthy. WanGP's base UI plus a couple of plugins
+        crosses that threshold on slower machines (reported on Pinokio/Windows
+        with two plugins enabled; disabling plugins "fixes" it by shrinking the
+        UI). Patch the probe: after the stock check gives up, retry loopback URLs
+        once with a long timeout — and proxies bypassed, since localhost must not
+        be routed through HTTP_PROXY. Non-loopback URLs (the share-tunnel polling
+        loop) keep stock behavior, and a genuinely dead localhost still fails
+        fast: connection-refused returns immediately in both passes."""
+        try:
+            import httpx
+            from gradio import networking
+        except Exception:
+            print("Warning: could not locate gradio.networking; leaving the localhost probe untouched.")
+            return
+        if getattr(networking, "_wan2gp_patient_url_ok", False):
+            return
+        orig_url_ok = getattr(networking, "url_ok", None)
+        if orig_url_ok is None:
+            return
+
+        local_prefixes = ("http://localhost", "http://127.", "http://[::1]", "http://0.0.0.0")
+
+        def patient_url_ok(url):
+            if orig_url_ok(url):
+                return True
+            if not str(url).lower().startswith(local_prefixes):
+                return False
+            print("Gradio's localhost probe timed out (a large UI is slow to serve its first page); retrying with a 60s timeout...")
+            try:
+                r = httpx.head(url, timeout=60, verify=False, trust_env=False)
+            except Exception:
+                return False
+            # The status set gradio 5.29 accepts (401/302 when auth is set; 303/307 redirects).
+            return r.status_code in (200, 401, 302, 303, 307)
+
+        networking.url_ok = patient_url_ok
+        # The ImageSuite and Prompt Library plugins ship this same shim; setting
+        # their sentinels tells them the host already handled it so nothing stacks.
+        networking._wan2gp_patient_url_ok = True
+        networking._imagesuite_patient_url_ok = True
+        networking._promptlib_patient_url_ok = True
+
+    patch_gradio_localhost_probe()
     demo.launch(
         favicon_path="favicon.png",
         server_name=server_name,


### PR DESCRIPTION
## Problem

WanGP can crash at startup with:

```
ValueError: When localhost is not accessible, a shareable link must be created.
Please set share=True or check your proxy settings to allow access to localhost.
```

This was reported by a Pinokio/Windows user who had just enabled two plugins (ImageSuite + Prompt Library); disabling the plugins in `wgp_config.json` made it start again. Nothing was wrong with their network — the trigger is UI size.

## Root cause

Gradio 5.29's `launch()` verifies localhost by probing `HEAD /` with `httpx.head(timeout=3)`, 5 attempts. But serving `/` deep-copies the entire Blocks config **and** filters components per page with `component["id"] in config["page"][page]["components"]` — membership tests against a plain list, i.e. **O(N²)** in component count (gradio `routes.py`, still present on gradio main).

Measured per-request cost of the `/` handler on a fast Linux box (gradio 5.29.0):

| components | deepcopy | id-filter | first response |
|---|---|---|---|
| 8k | 0.08s | 0.13s | ~0.3s |
| 16k | 0.20s | 0.53s | ~0.8s |
| 32k | 0.32s | 2.22s | **>3s → launch() raises** |

A plugin-free synthetic Blocks app at ~32k components reproduces the exact crash on a fast machine; slower Windows machines fail at far lower counts. WanGP's base UI plus a couple of plugin tabs is enough to cross the threshold — which is why "disable plugins" looks like a fix.

The same mechanism also explains intermittent sightings on fast machines without plugins: the probe allows five attempts of exactly 3s over a ~17s window at the busiest moment of startup. A borderline first response (WanGP's base UI alone costs a second or two) plus one unlucky burst of contention in that window — first-request template compile, model preloading, antivirus scanning freshly-touched checkpoints — pushes all five attempts over. Deterministic for big-UI setups, a race for everyone else.

## Fix

Patch `gradio.networking.url_ok` just before `demo.launch()`: run the stock probe first, unchanged; only when it gives up, retry **loopback URLs only** once with a 60s timeout and `trust_env=False` (a system HTTP proxy must not intercept a localhost probe — proxies are the other classic trigger of this same error).

Properties:

- Normal startups are byte-for-byte identical: the stock probe runs first and passes as before.
- A genuinely dead localhost still fails fast — connection-refused returns immediately in both passes; only "alive but slow to serve the first page" is rescued.
- The share-tunnel polling loop (`while not networking.url_ok(self.share_url)`) is untouched: patience applies to loopback URLs only.
- Idempotent, and coordinates via sentinel attributes with the identical shims already shipped in the ImageSuite and Prompt Library plugins (so exactly one patch installs regardless of load order). A host-side fix is still the right place: any sufficiently large plugin reproduces this, not just the two that patched around it.
- If gradio's internals ever move, the patch logs a note and leaves everything untouched.

Verified against gradio 5.29.0: the 32k-component app that crashes stock `launch()` starts successfully with the patch, and both plugin shims correctly back off when the host patch is present.

The real long-term fix is one line in gradio's `routes.py` (`set(...)` around the page-membership lists); I'll file that upstream separately. This patch keeps WanGP startable in the meantime and remains harmless once gradio fixes it.
