### PR TITLE
fix(downloads): stage HF subfolder downloads in OS temp dir (Windows MAX_PATH)

### DIFF
--- a/shared/utils/download.py
+++ b/shared/utils/download.py
@@ -1,4 +1,4 @@
-import os, shutil, sys, time
+import os, shutil, sys, tempfile, time
 
 # Global variables to track download progress
 _start_time = None
@@ -226,12 +226,19 @@ def download_file(url, filename):
         else:
             tgt = fl.get_download_location() if len(base_dir) == 0 else base_dir
             os.makedirs(tgt, exist_ok=True)
-            temp_dir_path = os.path.join(tgt, f"_temp{time.time()}")
+            # Stage in the OS temp dir (short path) instead of under ckpts:
+            # huggingface_hub writes its .cache/huggingface/download staging tree
+            # next to local_dir, which can exceed Windows' 260-char MAX_PATH when
+            # the install path is deep and the filename is long (issue: WinError 3
+            # "'...safetensors.metadata' The system cannot find the path specified").
+            temp_dir_path = tempfile.mkdtemp(prefix="_temp")
             temp_full_path = os.path.join(temp_dir_path, sourceFolder)
             os.makedirs(temp_full_path, exist_ok=True)
-            hf_hub_download(repo_id=repoId, filename=onefile, local_dir=temp_dir_path, subfolder=sourceFolder)
-            shutil.move(os.path.join(temp_full_path, onefile), tgt)
-            shutil.rmtree(temp_dir_path)
+            try:
+                hf_hub_download(repo_id=repoId, filename=onefile, local_dir=temp_dir_path, subfolder=sourceFolder)
+                shutil.move(os.path.join(temp_full_path, onefile), tgt)
+            finally:
+                shutil.rmtree(temp_dir_path, ignore_errors=True)
     else:
         from urllib.request import urlretrieve
 


### PR DESCRIPTION
## Problem

Downloading models whose files live in a subfolder of a HF repo (e.g. the LTX-2 text encoder `gemma-3-12b-it-qat-q4_0-unquantized/…safetensors`) fails on Windows with:

```
[WinError 3] The system cannot find the path specified: 'C:\Users\…\wan2gp-desktop\Wan2GP\Wan2GP\ckpts\gemma-3-12b-it-qat-q4_0-unquantized\_temp1786362921.6263518\.cache\huggingface\download\gemma-3-12b-it-qat-q4_0-unquantized\…_quanto_bf16_int8.safetensors.metadata'
```

surfaced by `download_models()` as `'<url>' is invalid for Model 'ltx2_19B'`.

Root cause: the subfolder branch of `download_file()` stages inside the ckpts tree (`os.path.join(tgt, f"_temp{time.time()}")`). `hf_hub_download(local_dir=…)` writes its own `.cache/huggingface/download/<subfolder>/<file>.metadata` staging tree next to `local_dir`, and for deep install paths (`%APPDATA%\wan2gp-desktop\Wan2GP\Wan2GP\ckpts\` + 35-char folder name + 73-char filename) that path reaches **263 chars > Windows' 260-char MAX_PATH limit** → `[WinError 3]`.

## Fix

Stage in the OS temp dir via `tempfile.mkdtemp()` instead — the path stays short (~185 chars in the same scenario) regardless of install depth or username — and clean up in a `finally` block so failed downloads don't leak the temp tree.

Verified with a simulation of the exact failing paths: staging path drops from 263 → 185 chars, destination file lands correctly, temp dir removed.

Same-volume note: `%TEMP%` is on the system drive, so the final `shutil.move` into the ckpts tree stays an instant rename; `shutil.move` falls back to copy+delete if TEMP is ever on another volume.