### PR TITLE
feat(minimax_h3): Text-to-Image mode with multi-seed stills

### DIFF
--- a/models/minimax_h3/components/video_autoencoder.py
+++ b/models/minimax_h3/components/video_autoencoder.py
@@ -911,6 +911,27 @@ class AutoencoderKLMiniMaxH3(ModelMixin, ConfigMixin, AttentionMixin, Autoencode
         if pad_tokens > 0:
             z = torch.cat([z, z[:, :, -1:].repeat(1, 1, pad_tokens, 1, 1)], dim=2)
 
+        # Minimum geometry is 5 pixel frames <-> 2 latent tokens (n=0 in 17*n+5 / 5*n+2).
+        # Restoring token_drop yields exactly one tokens_chunk_size window, so the generic
+        # formula sets num_chunks=0 and would write nothing (decoded 0, expected 5). Handle
+        # that single window explicitly: pad the decode view, strip pre-padding, keep 5 frames.
+        if num_chunks <= 0:
+            if z.shape[2] <= 0:
+                raise RuntimeError("MiniMax H3 VAE decode received empty latents")
+            min_len = tokens_chunk_size + self.token_overlap
+            if z.shape[2] < min_len:
+                z = torch.cat([z, z[:, :, -1:].repeat(1, 1, min_len - z.shape[2], 1, 1)], dim=2)
+            clip = self._decode_clip(z[:, :, :min_len])
+            chunk = clip[:, :, self.frame_pre_padding :]
+            # n=0 pixel length: clip_length frames were encoded with pad, real content is 5.
+            output_frames = self.config.clip_length + self.frame_overlap - chunk_num_frames + self.frame_pre_padding
+            output_frames = max(1, int(output_frames))
+            if chunk.shape[2] < output_frames:
+                raise RuntimeError(
+                    f"MiniMax H3 VAE minimum-length decode produced {chunk.shape[2]} frames, expected at least {output_frames}"
+                )
+            return chunk[:, :, :output_frames].contiguous()
+
         intra_tail = self.config.clip_length % temporal_ratio
         num_tokens_before_pad = z.shape[2] - pad_tokens
         pad_frames = sum(

--- a/models/minimax_h3/minimax_h3_handler.py
+++ b/models/minimax_h3/minimax_h3_handler.py
@@ -111,6 +111,10 @@ See the [MiniMax H3 model card](https://huggingface.co/MiniMaxAI/MiniMax-H3/blob
 """
 
 H3_RUNTIME_INFOS = """
+### Image mode (stills)
+
+Use the **Text to Image** tab to run H3 as a still generator. WanGP runs the shortest legal clip (**5 frames**), keeps the **first frame** as the image, and skips audio. Use **Number of Images** for multiple **independent** takes (different seeds) of the same prompt — each image is a full short generation, not frames from one clip. Optional reference images still work on Ref2VA. Video mode is unchanged.
+
 ### Speed and memory choices
 
 Enable **Advanced Mode** to access these options:
@@ -183,6 +187,9 @@ class family_handler:
             "dtype": "bf16",
             "fps": 24,
             "frames_minimum": 107,
+            # Image mode uses the model-legal minimum (5 + 17n). Each generated frame is
+            # exported as its own gallery image, so a 5-frame still run yields 5 variations.
+            "frames_minimum_image": 5,
             "frames_steps": 17,
             "frames_offset": 5,
             "block_size": 32,
@@ -202,6 +209,13 @@ class family_handler:
             "returns_audio": True,
             "multimedia_generation": True,
             "control_video_trim_disabled": True,
+            # Video ↔ Image switch in Media Generator. Image mode forces the shortest
+            # legal clip (5 frames), drops audio, keeps the first frame as the still.
+            # Number of Images runs independent multi-seed gens (true different takes).
+            "v2i_switch_supported": True,
+            "image_batch_size_max": 8,
+            "image_mode_keep_all_frames": False,
+            "batch_size_label": "Number of Images (independent seeds)",
             "infos": (REF2VA_INFOS if reference_mode else FL2VA_INFOS) + H3_RUNTIME_INFOS + (PRUNED_INFOS if pruned else ""),
             "prompt_infos": REF2VA_PROMPT_INFOS if reference_mode else FL2VA_PROMPT_INFOS,
             "prompt_enhancer_button_label": "Write H3 Prompt",
@@ -275,6 +289,14 @@ class family_handler:
                     "default": "",
                     "label": "Reference / Control Video",
                 },
+                # Image mode: stills from text + optional reference images (no video controls).
+                "guide_custom_choices_image": {
+                    "choices": [("Generate without a Control Image", "")],
+                    "letters_filter": "",
+                    "default": "",
+                    "label": "Control Image",
+                    "visible": False,
+                },
                 "preprocess_video_guide2": True,
                 "reference_video_max_frames": 15 * 24,
                 "reference_video_max_size": (768, 1344),
@@ -316,6 +338,13 @@ class family_handler:
                     "letters_filter": "GVKFI",
                     "default": "",
                     "label": "Control Video / Frames Injection",
+                },
+                "guide_custom_choices_image": {
+                    "choices": [("Generate without a Control Image", "")],
+                    "letters_filter": "",
+                    "default": "",
+                    "label": "Control Image",
+                    "visible": False,
                 },
                 "video_guide_label": "Control Video",
                 "mask_preprocessing": {"selection": ["", "A", "NA"]},
@@ -527,6 +556,9 @@ class family_handler:
             "audio_prompt_type": "",
             "video_prompt_type": "",
             "image_mode": 0,
+            # Shortest legal H3 clip; first frame kept as the still.
+            "min_frames_if_references": 1,
+            "batch_size": 1,
         })
         if reference_mode:
             ui_defaults.update({"image_refs_relative_size": 100, "remove_background_images_ref": 0})

--- a/models/minimax_h3/pipeline.py
+++ b/models/minimax_h3/pipeline.py
@@ -343,11 +343,74 @@ class MiniMaxH3Pipeline:
                  input_masks=None, denoising_strength=1.0, masking_strength=1.0,
                  input_video=None, input_waveform=None, input_waveform_sample_rate=None,
                  audio_guide=None, audio_guide2=None, prefix_frames_count=0,
-                 frame_num=124, height=768, width=1344, shift=12.0, sampling_steps=30, seed=0,
-                 callback=None, VAE_tile_size=None, audio_prompt_type="", video_prompt_type="", fps=24,
-                 sample_solver="euler",
-                 set_progress_status=None, **kwargs):
-        fps = float(fps)
+                  frame_num=124, height=768, width=1344, shift=12.0, sampling_steps=30, seed=0,
+                  callback=None, VAE_tile_size=None, audio_prompt_type="", video_prompt_type="", fps=24,
+                  sample_solver="euler",
+                  set_progress_status=None, image_mode=0, **kwargs):
+        image_mode = int(image_mode or kwargs.pop("image_mode", 0) or 0)
+        # True multi-image: N independent short gens with different seeds (not N frames of one clip).
+        image_batch_size = max(1, int(kwargs.pop("batch_size", 1) or 1)) if image_mode > 0 else 1
+        if image_mode > 0 and image_batch_size > 1:
+            import random
+            base_seed = int(seed) if seed is not None else random.randint(0, 2**31 - 1)
+            stills = []
+            for image_index in range(image_batch_size):
+                if set_progress_status is not None:
+                    set_progress_status(f"H3 still {image_index + 1}/{image_batch_size}")
+                one = self.generate(
+                    input_prompt,
+                    image_start=image_start,
+                    image_end=image_end,
+                    input_frames=input_frames,
+                    input_frames2=input_frames2,
+                    input_ref_images=input_ref_images,
+                    frames_to_inject=frames_to_inject,
+                    frames_relative_positions_list=frames_relative_positions_list,
+                    image_refs_relative_size=image_refs_relative_size,
+                    input_masks=input_masks,
+                    denoising_strength=denoising_strength,
+                    masking_strength=masking_strength,
+                    input_video=input_video,
+                    input_waveform=input_waveform,
+                    input_waveform_sample_rate=input_waveform_sample_rate,
+                    audio_guide=audio_guide,
+                    audio_guide2=audio_guide2,
+                    prefix_frames_count=prefix_frames_count,
+                    frame_num=frame_num,
+                    height=height,
+                    width=width,
+                    shift=shift,
+                    sampling_steps=sampling_steps,
+                    seed=base_seed + image_index,
+                    callback=callback,
+                    VAE_tile_size=VAE_tile_size,
+                    audio_prompt_type=audio_prompt_type,
+                    video_prompt_type=video_prompt_type,
+                    fps=fps,
+                    sample_solver=sample_solver,
+                    set_progress_status=set_progress_status,
+                    image_mode=image_mode,
+                    batch_size=1,
+                    **kwargs,
+                )
+                if one is None:
+                    return None
+                still = one.get("x")
+                if still is None:
+                    return None
+                if still.ndim == 4 and still.shape[1] > 1:
+                    still = still[:, :1]
+                stills.append(still.contiguous())
+            seeds_used = [base_seed + image_index for image_index in range(image_batch_size)]
+            return {
+                "x": torch.cat(stills, dim=1),
+                "audio": None,
+                "audio_sampling_rate": AUDIO_SAMPLE_RATE,
+                "seeds": seeds_used,
+            }
+
+        # Image mode still needs H3's native temporal rate for latent geometry; WanGP may pass fps=1.
+        fps = 24.0 if image_mode > 0 else float(fps)
         if fps <= 0:
             raise ValueError("MiniMax H3 requires a positive output frame rate")
         self._set_interrupt_state()
@@ -357,7 +420,13 @@ class MiniMaxH3Pipeline:
             raise ValueError(f"Unsupported MiniMax H3 sampler {sample_solver!r}")
         if int(sampling_steps) < 1:
             raise ValueError("MiniMax H3 requires at least one inference step")
-        frame_num = normalize_frame_count(int(frame_num), 5, 17, 5)
+        # Image mode uses the shortest legal clip (5 frames) unless the caller requests a longer
+        # 5+17n length for quality; only the first frame is kept as the still.
+        if image_mode > 0:
+            frame_num = normalize_frame_count(max(5, int(frame_num or 5)), 5, 17, 5)
+            audio_prompt_type = ""
+        else:
+            frame_num = normalize_frame_count(int(frame_num), 5, 17, 5)
         audio_from_control_video = not self.reference_mode and "2" in (audio_prompt_type or "")
         prefix_frames_count, overlap_error = normalize_overlap(int(prefix_frames_count or 0), 17, 1)
         if overlap_error:
@@ -596,21 +665,34 @@ class MiniMaxH3Pipeline:
         initial_video = initial_audio = None
 
         if set_progress_status is not None:
-            set_progress_status("Decoding H3 stereo audio" if frozen_target_video is not None else "VAE Decoding of Video and Audio")
+            if image_mode > 0:
+                set_progress_status("VAE Decoding of Image Frames")
+            else:
+                set_progress_status("Decoding H3 stereo audio" if frozen_target_video is not None else "VAE Decoding of Video and Audio")
         self._check_abort()
         context = payload = presentation = visual_latents = audio_latents = refs = keyframes = audio_keyframes = source_latents = source_noise = source_buffer = editable_mask = None
         decoded_video = (self.vae.decode(video.to(self.vae._model_dtype)).clamp_(-1.0, 1.0)[0, :, :target_frames].cpu()
                          if frozen_target_video is None else frozen_target_video[:, :target_frames].cpu())
         video = None
-        decoded_audio = self.audio_vae.decode(audio)[0]
-        audio = None
-        target_samples = round(target_frames / fps * AUDIO_SAMPLE_RATE)
-        decoded_audio = _fit_audio_samples(decoded_audio, target_samples)
 
         output_prefix = history_frames
         output_prefix_count = history_count
         if output_prefix is not None:
             decoded_video = torch.cat((output_prefix.to(decoded_video), decoded_video), dim=1)
+
+        # Image mode: one still per generation (first frame only). Multi-image uses separate seeds above.
+        if image_mode > 0:
+            if decoded_video.shape[1] > 1:
+                decoded_video = decoded_video[:, :1].contiguous()
+            audio = None
+            return {"x": decoded_video, "audio": None, "audio_sampling_rate": AUDIO_SAMPLE_RATE}
+
+        decoded_audio = self.audio_vae.decode(audio)[0]
+        audio = None
+        target_samples = round(target_frames / fps * AUDIO_SAMPLE_RATE)
+        decoded_audio = _fit_audio_samples(decoded_audio, target_samples)
+
+        if output_prefix is not None:
             if history_waveform is not None:
                 prefix_samples = round(output_prefix_count / fps * AUDIO_SAMPLE_RATE)
                 prefix_audio = _fit_audio_samples(history_waveform[0].to(decoded_audio), prefix_samples)

--- a/shared/utils/media_recording.py
+++ b/shared/utils/media_recording.py
@@ -31,6 +31,21 @@ def record_file_metadata(video_path: str | list[str], configs: Any, is_image: bo
     for no, path in enumerate(paths):
         previous_path = None
         saved_configs = _ensure_creation_metadata(configs)
+        # Multi-image batches often share one task seed while models generate with seed+index
+        # (e.g. MiniMax H3 image mode). Record the per-image seed so metadata matches reality.
+        if (
+            is_image
+            and isinstance(saved_configs, dict)
+            and len(paths) > 1
+            and saved_configs.get("seed") is not None
+        ):
+            try:
+                base_seed = int(saved_configs["seed"])
+                if base_seed >= 0:
+                    saved_configs = dict(saved_configs)
+                    saved_configs["seed"] = base_seed + no
+            except (TypeError, ValueError):
+                pass
         if configs is not None:
             if metadata_choice == "json":
                 with open(os.path.splitext(path)[0] + ".json", "w") as f:

--- a/wgp.py
+++ b/wgp.py
@@ -958,7 +958,11 @@ def validate_settings(state, model_type, single_prompt, inputs, silent=False):
     image_outputs = inputs["image_mode"] > 0
     if image_outputs:
         image_batch_size_max = max(1, int(model_def.get("image_batch_size_max", 16)))
-        if int(inputs.get("batch_size", 1) or 1) > image_batch_size_max:
+        try:
+            inputs["batch_size"] = max(1, int(float(inputs.get("batch_size", 1) or 1)))
+        except (TypeError, ValueError):
+            inputs["batch_size"] = 1
+        if inputs["batch_size"] > image_batch_size_max:
             return err(f"This model supports a maximum of {image_batch_size_max} image{'s' if image_batch_size_max > 1 else ''} per generation.")
     is_edit_mode = str(inputs.get("mode", "") or "").startswith("edit_")
     any_steps_skipping = model_def.get("tea_cache", False) or model_def.get("mag_cache", False) or model_def.get("spectrum_cache", False) or model_def.get("first_block_cache", False)
@@ -983,6 +987,10 @@ def validate_settings(state, model_type, single_prompt, inputs, silent=False):
         return err("Prompt cannot be empty.")
     validation_prompts = prompts
     frames_minimum, frames_steps, latent_size = get_model_min_frames_and_step(model_type)
+    if image_outputs:
+        image_frames_minimum = model_def.get("frames_minimum_image", None)
+        if image_frames_minimum is not None:
+            frames_minimum = max(1, int(image_frames_minimum))
     inputs.pop("frame_scheduler", None)
     frame_scheduler = None
     scheduler_supported = frame_scheduler_supported(model_type, model_def, inputs.get("image_mode", 0), is_edit_mode)
@@ -6610,6 +6618,7 @@ def generate_media(
     preprocess_video_guide2 = model_def.get("preprocess_video_guide2", False)
     if is_image:
         image_batch_size_max = max(1, int(model_def.get("image_batch_size_max", 16)))
+        batch_size = max(1, int(batch_size or 1))
         if batch_size > image_batch_size_max:
             raise ValueError(f"This model supports a maximum of {image_batch_size_max} image{'s' if image_batch_size_max > 1 else ''} per generation.")
         if not model_def.get("custom_video_length", False):
@@ -6743,6 +6752,11 @@ def generate_media(
     prompts = prompt_parser.split_prompt_units(prompt, multi_prompts_gen_type)
     display_prompts = prompts.copy()
     frames_minimum, frames_steps, latent_size = get_model_min_frames_and_step(model_type)
+    # Image mode may use a lower legal minimum than video (e.g. MiniMax H3: 5 vs 107).
+    if is_image:
+        image_frames_minimum = model_def.get("frames_minimum_image", None)
+        if image_frames_minimum is not None:
+            frames_minimum = max(1, int(image_frames_minimum))
     parsed_keep_frames_video_source= max_source_video_frames if len(keep_frames_video_source) ==0 else int(keep_frames_video_source) 
     transformer_loras_filenames, transformer_loras_multipliers  = get_transformer_loras(model_type)
     lora_dir = get_lora_dir(model_type)
@@ -7759,6 +7773,7 @@ def generate_media(
             post_decode_pre_trim = 0
             output_audio_sampling_rate= audio_sampling_rate
             sample_is_hdr = False
+            image_output_seeds = None
             if samples != None:
                 if isinstance(samples, dict):
                     sample_is_hdr = samples.get("hdr", False)
@@ -7767,6 +7782,7 @@ def generate_media(
                     generated_audio = samples.get("audio", generated_audio)
                     overridden_inputs = samples.get("overridden_inputs", None)
                     output_audio_sampling_rate = samples.get("audio_sampling_rate", audio_sampling_rate)
+                    image_output_seeds = samples.get("seeds", None)
                     input_fills_window = input_waveform is not None and input_waveform.shape[0] >= int(round(current_video_length * input_waveform_sample_rate / fps))
                     if generated_audio is not None:
                         if model_def.get("output_audio_is_input_audio", False) and output_new_audio_filepath is not None and "O" not in audio_prompt_type and input_fills_window:
@@ -7953,8 +7969,20 @@ def generate_media(
                     image_path = os.path.join(output_dir, file_name)
                     sample =  sample.transpose(1,0)  #c f h w -> f c h w 
                     new_image_path = []
-                    for no, img in enumerate(sample):  
-                        img_path = os.path.splitext(image_path)[0] + ("" if no==0 else f"_{no}") + ".jpg" 
+                    # Multi-still batches (e.g. H3 independent seeds) use seed, seed+1, ...
+                    base_image_seed = seed if seed is not None else None
+                    for no, img in enumerate(sample):
+                        if base_image_seed is not None and sample.shape[0] > 1:
+                            img_seed = int(base_image_seed) + no
+                            stem = os.path.splitext(image_path)[0]
+                            # Prefer unique seed in the filename when several stills share one task.
+                            if f"_seed{base_image_seed}_" in stem or stem.endswith(f"_seed{base_image_seed}"):
+                                stem = stem.replace(f"_seed{base_image_seed}", f"_seed{img_seed}", 1)
+                                img_path = stem + ".jpg"
+                            else:
+                                img_path = os.path.splitext(image_path)[0] + ("" if no == 0 else f"_{no}") + ".jpg"
+                        else:
+                            img_path = os.path.splitext(image_path)[0] + ("" if no == 0 else f"_{no}") + ".jpg"
                         new_image_path.append(save_image(img, save_file = img_path, quality = server_config.get("image_output_codec", None)))
 
                     video_path= new_image_path
@@ -8083,7 +8111,14 @@ def generate_media(
                 configs["creation_date"] = datetime.fromtimestamp(end_time).isoformat(timespec="seconds")
                 configs["creation_timestamp"] = int(end_time)
                 # if sample_is_image: configs["is_image"] = True
-                record_file_metadata(video_path, configs, is_image, audio_only, gen, embedded_images=embedded_images, replace_last_file=sliding_window and window_no > 1 and not server_config.get("keep_intermediate_sliding_windows", 1))
+                # Prefer model-reported per-image seeds (H3 multi-still) over a single task seed.
+                if is_image and isinstance(video_path, list) and image_output_seeds and len(image_output_seeds) == len(video_path):
+                    for img_path, img_seed in zip(video_path, image_output_seeds):
+                        img_configs = dict(configs)
+                        img_configs["seed"] = int(img_seed)
+                        record_file_metadata(img_path, img_configs, is_image, audio_only, gen, embedded_images=embedded_images, replace_last_file=False)
+                else:
+                    record_file_metadata(video_path, configs, is_image, audio_only, gen, embedded_images=embedded_images, replace_last_file=sliding_window and window_no > 1 and not server_config.get("keep_intermediate_sliding_windows", 1))
                 if api_return_video_uint8 or api_return_audio or return_flashvsr_continue_cache:
                     media_type = "audio" if audio_only else ("image" if is_image else "video")
                     artifact_audio = output_new_audio_data if api_return_audio else None
@@ -11842,7 +11877,33 @@ def generate_media_tab(update_form = False, state_dict = None, ui_defaults = Non
                 batch_label = model_def.get("batch_size_label", "Number of Images to Generate")
                 batch_size_max = max(1, int(model_def.get("image_batch_size_max", 16)))
                 batch_size_value = min(batch_size_max, max(1, int(ui_get("batch_size") or 1)))
-                batch_size = gr.Slider(1, batch_size_max, value=batch_size_value, step=1, label=batch_label, visible = image_outputs, show_reset_button= False)
+                # Always interactive=True (do not bind to image_outputs). v2i models build this
+                # control first in Video mode; Gradio form refresh often keeps interactive=False
+                # if it started disabled, which made the old slider look stuck.
+                # Radio for small maxima (H3-style); Slider for large maxima (Flux/Z-Image).
+                if batch_size_max <= 8:
+                    batch_size_choices = [(f"{n}", n) for n in range(1, batch_size_max + 1)]
+                    batch_size = gr.Radio(
+                        choices=batch_size_choices,
+                        value=batch_size_value if 1 <= batch_size_value <= batch_size_max else 1,
+                        label=batch_label,
+                        visible=image_outputs,
+                        interactive=True,
+                        elem_id="wangp_image_batch_size",
+                        info=f"Each value = separate stills with different seeds (1–{batch_size_max})." if batch_size_max > 1 else "This model generates one image per run.",
+                    )
+                else:
+                    batch_size = gr.Slider(
+                        minimum=1,
+                        maximum=batch_size_max,
+                        value=batch_size_value,
+                        step=1,
+                        label=batch_label,
+                        visible=image_outputs,
+                        interactive=True,
+                        show_reset_button=False,
+                        elem_id="wangp_image_batch_size",
+                    )
                 if image_outputs:
                     video_length = gr.Slider(1, 9999, value=ui_get("video_length"), step=1, label="Number of frames", visible = False, show_reset_button= False)
                 else:
@@ -12129,24 +12190,41 @@ def generate_media_tab(update_form = False, state_dict = None, ui_defaults = Non
                                 cfg_zero_step = gr.Slider(-1, 39, value=ui_get("cfg_zero_step"), step=1, label="CFG Zero below this Layer (Extra Process)", visible = any_cfg_zero, show_reset_button= False) 
 
                         with gr.Column(visible = v2i_switch_supported and image_outputs) as min_frames_if_references_col:
-                            gr.Markdown("<B>WanGP normally runs the shortest model-compatible generation and keeps its first frame. Generating additional frames may improve still-image quality or preserve Reference / Control Image details, at extra generation cost.</B>")
+                            keep_all_image_frames = bool(model_def.get("image_mode_keep_all_frames", False))
+                            if keep_all_image_frames:
+                                gr.Markdown("<B>This model exports every generated frame as a separate still. The shortest run already yields several image variations from one prompt. Longer runs add more frames (and more stills) at extra cost.</B>")
+                            else:
+                                gr.Markdown("<B>WanGP normally runs the shortest model-compatible generation and keeps its first frame. Generating additional frames may improve still-image quality or preserve Reference / Control Image details, at extra generation cost.</B>")
                             _, _, temporal_latent = get_model_min_frames_and_step(base_model_type)
                             temporal_latent = max(1, int(temporal_latent or 1))
                             frames_offset = max(0, int(model_def.get("frames_offset", 1)))
-                            first_frame_count = frames_offset if frames_offset > 1 else temporal_latent + frames_offset
+                            image_frames_minimum = model_def.get("frames_minimum_image", None)
+                            if image_frames_minimum is not None:
+                                first_frame_count = max(1, int(image_frames_minimum))
+                            else:
+                                first_frame_count = frames_offset if frames_offset > 1 else temporal_latent + frames_offset
                             frame_counts = [first_frame_count + temporal_latent * index for index in range(4)]
-                            image_mode_video_frame_choices = [("Shortest generation, keep only the First Frame", 1)]
-                            image_mode_video_frame_choices += [(f"Generate {frame_count} Frames and keep the First only when using a Reference / Control Image", frame_count) for frame_count in frame_counts]
-                            image_mode_video_frame_choices += [(f"Always generate {frame_count} Frames and keep the First", 1000 + frame_count) for frame_count in frame_counts]
-                            min_frames_if_references_value = ui_get("min_frames_if_references", frame_counts[1] if vace else 1)
+                            if keep_all_image_frames:
+                                image_mode_video_frame_choices = [(f"Shortest generation ({frame_counts[0]} frames → {frame_counts[0]} stills)", 1)]
+                                image_mode_video_frame_choices += [(f"Generate {frame_count} frames → {frame_count} stills when using a Reference / Control Image", frame_count) for frame_count in frame_counts]
+                                image_mode_video_frame_choices += [(f"Always generate {frame_count} frames → {frame_count} stills", 1000 + frame_count) for frame_count in frame_counts]
+                                frames_dropdown_label = "How many frames / stills to generate"
+                                default_min_frames = frame_counts[0]
+                            else:
+                                image_mode_video_frame_choices = [("Shortest generation, keep only the First Frame", 1)]
+                                image_mode_video_frame_choices += [(f"Generate {frame_count} Frames and keep the First only when using a Reference / Control Image", frame_count) for frame_count in frame_counts]
+                                image_mode_video_frame_choices += [(f"Always generate {frame_count} Frames and keep the First", 1000 + frame_count) for frame_count in frame_counts]
+                                frames_dropdown_label = "Generate additional frames before keeping the first image"
+                                default_min_frames = frame_counts[1] if vace else 1
+                            min_frames_if_references_value = ui_get("min_frames_if_references", default_min_frames)
                             if min_frames_if_references_value not in {choice[1] for choice in image_mode_video_frame_choices}:
-                                min_frames_if_references_value = 1
+                                min_frames_if_references_value = default_min_frames
                             min_frames_if_references = gr.Dropdown(
                                 choices=image_mode_video_frame_choices,
                                 value=min_frames_if_references_value,
                                 visible=True,
                                 scale = 1,
-                                label="Generate additional frames before keeping the first image"
+                                label=frames_dropdown_label
                             )
 
                         with gr.Column(visible = get_container_def("motion_amplitude_col").visible and not image_outputs) as motion_amplitude_col:


### PR DESCRIPTION
## Summary
- Adds **Text to Image** mode for all MiniMax H3 architectures (FL2VA / Ref2VA + pruned 20B).
- Image mode runs the shortest legal H3 clip (**5 frames**), keeps the **first frame** as the still, and skips audio export.
- **Number of Images** runs **independent multi-seed** generations (true different takes), not frames from one clip.
- Fixes VAE decode crash on the 5-frame minimum (`decoded 0 frames, expected 5`).
- Fixes v2i batch control stuck non-interactive after Video→Image form refresh.
- Records **per-image seeds** in metadata/filenames for multi-still batches.

## Motivation
H3 is strong for multi-reference identity work. Running it as short stills (with optional refs on Ref2VA) makes that usable without a full video render. Community workflows (e.g. multi-ref still sheets) already treat H3 this way in Comfy; this brings a first-class path into WanGP.

## Behavior
| Mode | Behavior |
|------|----------|
| **Text to Video** | Unchanged (default min length stays video-oriented) |
| **Text to Image** | 5-frame clip → keep frame 0 → JPG gallery |
| **Number of Images = N** | N separate short gens with seeds `S, S+1, …` |

### Model coverage
- `minimax_h3_fl2va` / `minimax_h3_fl2va_pruned` — text / start-image stills  
- `minimax_h3_ref2va` / `minimax_h3_ref2va_pruned` — multi-ref stills  

## Implementation notes
- Handler: `v2i_switch_supported`, `frames_minimum_image: 5`, `image_batch_size_max: 8`, `image_mode_keep_all_frames: false`
- Pipeline: image-mode path, multi-seed loop, returns `seeds` list for metadata
- VAE: minimum-length decode path for 2 latent tokens (5 pixel frames)
- `wgp.py`: honors `frames_minimum_image`; batch control always `interactive=True` (Radio when max≤8, Slider otherwise) so v2i refresh does not leave controls disabled
- `media_recording`: per-image seed when saving multi-image batches

## Test plan
- [x] H3 Ref2VA → Text to Image → single still succeeds
- [x] H3 Ref2VA → Number of Images = 2–3 → distinct stills
- [x] Metadata/filename seeds differ per still (`S`, `S+1`, …)
- [x] No more `VAE decoded 0 frames, expected 5`
- [x] Batch control clickable after switching Video → Image
- [ ] H3 FL2VA Text to Image smoke
- [ ] H3 Text to Video still works (length/audio unchanged)
- [ ] Non-H3 image models (e.g. Z-Image/Flux) batch control still OK

## Discord-friendly blurb
See PR comment / release note style summary in the discussion if useful for #announcements.