### PR TITLE
fix(setup): repair present-but-broken .git during update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import subprocess
 import argparse
 import shutil
 import platform
+import time
 
 CONFIG_PATH = "setup_config.json"
 ENVS_FILE = "envs.json"
@@ -993,9 +994,26 @@ def inject_system_paths():
 
     os.environ["PATH"] = current_path
 
+def git_repo_is_valid():
+    try:
+        subprocess.run(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        )
+        return True
+    except Exception:
+        return False
+
 def repair_git_repo():
     print("[*] Repairing WAN2GP repository...")
-    if not os.path.exists(".git"):
+    if os.path.exists(".git") and not git_repo_is_valid():
+        # .git exists but is broken (AV quarantine / interrupted clone leaves
+        # HEAD, config or index missing). Move it aside so git init can rebuild.
+        broken = f".git.broken.{int(time.time())}"
+        print(f"[!] Existing .git is invalid, moving to {broken} and re-initializing...")
+        shutil.move(".git", broken)
+
+    if not os.path.exists(".git") or not git_repo_is_valid():
         run_cmd("git init")
 
     try:


### PR DESCRIPTION
## Problem

On Windows especially, `.git` can exist but be unusable: an antivirus quarantine or an interrupted `git clone --depth 1` leaves `HEAD`, `config` or `index` missing. Every git command then fails with:

```
fatal: not a git repository (or any of the parent directories): .git
```

`repair_git_repo()` only ran `git init` when `.git` was **absent**, so this state was unrecoverable — `git fetch origin` (line 1006) died with exit 128 on every `setup.py update`, forever, on both existing installs and fresh ones. Updates could never succeed again without the user manually deleting `.git`.

## Fix

- New `git_repo_is_valid()`: probes an existing `.git` with `git rev-parse --is-inside-work-tree` instead of trusting mere existence.
- `repair_git_repo()` now moves an invalid `.git` aside (`.git.broken.<ts>`) so `git init` can rebuild the repository from scratch. Valid repos take the exact same path as before — no behavior change.

The update flow already routes `git pull` failures into `repair_git_repo()`, so this single change makes the automatic recovery actually recover.

Verified: `python -m py_compile setup.py` passes; the repair logic ran against a real broken `.git` (no HEAD/config/index) — detected invalid, moved aside, `git init`, `rev-parse` green.
