### PR TITLE
chore(plugins): bump Wildcards plugin to v1.6.4

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -218,12 +218,12 @@
   {
     "name": "Wildcards",
     "author": "GKartist75 (with PI Agent)",
-    "version": "1.6.2",
+    "version": "1.6.4",
     "description": "Dynamic wildcard expansion for prompts + named variables + templates + character profiles + usage stats. Use __name__ syntax for random picks, __$var:file__ for reusable captured variables.",
     "type": [
       "extension"
     ],
-    "date": "2026-07-09",
+    "date": "2026-08-13",
     "wan2gp_version": "",
     "url": "https://github.com/GKartist75/wan2gp-wildcards"
   },


### PR DESCRIPTION
## Summary
Bumps the catalog entry for the **Wildcards** plugin from `1.6.2` → `1.6.4` in `plugins.json`.

The plugin repo (`GKartist75/wan2gp-wildcards`) has shipped v1.6.3 and v1.6.4 since this catalog entry was last updated. This keeps the Plugin Manager's "update available" detection accurate.

## Changes
- `Wildcards` entry: `version` `1.6.2` → `1.6.4`, `date` `2026-07-09` → `2026-08-13`.
- No other entries touched (verified diff is limited to the Wildcards block).

## What's new in v1.6.4 (plugin repo)
- Bug fixes: buffered usage stats (no per-expansion disk write), weighted `N::` requires numeric prefix, path-traversal rejection on file create/rename/save, validated character import, Seed honored in batch mode.
- Performance: wildcard line cache, cached file listing, capped cross-file search, sampled value chips.
- New **Check Prompt Template** linter button flags unresolved `__name__` references.
- First pytest suite (26 tests).

Release: https://github.com/GKartist75/wan2gp-wildcards/releases/tag/v1.6.4