### PR TITLE
Fix H3 Sol/Sage crash: force SDPA in Qwen3-VL vision encoder (head_dim 72)

### DIFF
--- a/models/hidream/qwen3_vl_transformers.py
+++ b/models/hidream/qwen3_vl_transformers.py
@@ -330,7 +330,7 @@ class Qwen3VLVisionAttention(nn.Module):
                 key_states[:, cursor:end].contiguous(),
                 value_states[:, cursor:end].contiguous(),
             ]
-            attn_outputs.append(pay_attention(qkv_list, softmax_scale=self.scaling, causal=False, recycle_q=True))
+            attn_outputs.append(pay_attention(qkv_list, softmax_scale=self.scaling, causal=False, force_attention="sdpa", recycle_q=True))
             cursor = end
         del query_states, key_states, value_states
         attn_output = _cat_tensors(attn_outputs, dim=1).reshape(seq_length, -1).contiguous()

--- a/models/ideogram4/qwen3_vl_transformers.py
+++ b/models/ideogram4/qwen3_vl_transformers.py
@@ -342,7 +342,7 @@ class Qwen3VLVisionAttention(nn.Module):
                 key_states[:, cursor:end].contiguous(),
                 value_states[:, cursor:end].contiguous(),
             ]
-            attn_outputs.append(pay_attention(qkv_list, softmax_scale=self.scaling, causal=False, recycle_q=True))
+            attn_outputs.append(pay_attention(qkv_list, softmax_scale=self.scaling, causal=False, force_attention="sdpa", recycle_q=True))
             cursor = end
         del query_states, key_states, value_states
         attn_output = _cat_tensors(attn_outputs, dim=1).reshape(seq_length, -1).contiguous()


### PR DESCRIPTION
## Summary

Fixes issue #2182 — MiniMax H3 (and HiDream) crash immediately under **Sol** or **Sage** attention with:

```
AssertionError: varlen only support head_dim [64, 128].
```

## Root cause

The Qwen3-VL **vision** encoder uses 72-dimensional attention heads. When the global attention mode is Sol/Sage, the vision path gets routed through `sageattn_varlen`, which only accepts `head_dim` 64 or 128, so it aborts during prompt encoding — before any video sampling starts.

## Fix

Force **only** the vision-attention path to SDPA (the text-encoder attention path in the same files already does this at lines 176/190). The model's main denoiser keeps using the user-selected Sol/Sage backend — the speed-up is unaffected.

```python
attn_outputs.append(pay_attention(qkv_list, softmax_scale=self.scaling, causal=False, force_attention="sdpa", recycle_q=True))
```

Applied to both:
- `models/ideogram4/qwen3_vl_transformers.py` (used by MiniMax H3 — `models/minimax_h3/text_encoder.py` imports from here)
- `models/hidream/qwen3_vl_transformers.py` (identical bug)

## Verification

- `python -m py_compile` passes on both files.
- Workaround independently confirmed by two users in #2182.

Tested by: select MiniMax H3 → Override Attention Mode → Sol (or Sage) → generate image-to-video → no longer crashes with the head_dim assertion.
