### PR TITLE
Fix 'Cannot Save Settings': clamp Configuration Boost dropdown to valid value

### DIFF
--- a/plugins/configuration/plugin.py
+++ b/plugins/configuration/plugin.py
@@ -294,7 +294,11 @@ class ConfigTabPlugin(WAN2GPPlugin):
                         value=vae_config_value,
                         label="VAE Tiling (higher presets use less VRAM and may increase artifacts like banding)",
                     )
-                    self.boost_choice = gr.Dropdown(choices=[("ON", 1), ("OFF", 2)], value=self.boost, label="Boost (~10% speedup for ~1GB VRAM)")
+                    # Clamp to a valid choice value: a stale 'boost' (e.g. from an older
+                    # wgp_config.json) outside {1, 2} bricks the Configuration save
+                    # ("Value: N is not in the list of choices: [1, 2]").
+                    boost_value = self.boost if self.boost in (1, 2) else 1
+                    self.boost_choice = gr.Dropdown(choices=[("ON", 1), ("OFF", 2)], value=boost_value, label="Boost (~10% speedup for ~1GB VRAM)")
                     self.enable_int8_kernels_choice = gr.Dropdown(choices=[("Disabled", 0), ("Enabled if Triton available", 1)], value=self.server_config.get("enable_int8_kernels", 1), label="Int8 Kernels (Experimental, 10% faster with INT8 quantized checkpoints, requires Triton)")
                     self.video_profile_choice = gr.Dropdown(
                         choices=self.memory_profile_choices,


### PR DESCRIPTION
## Summary

Fixes issue #2172 — "Cannot Save Settings" on the Configuration tab with:

```
Error
Value: 5 is not in the list of choices: [1, 2]
```

## Root cause

The **Boost** dropdown (`plugins/configuration/plugin.py`) is built with `choices=[("ON", 1), ("OFF", 2)]` and `value=self.boost`. If `wgp_config.json` carries a stale `boost` value from an older Wan2GP version (any integer outside `{1, 2}`, e.g. `5`), Gradio rejects it at save time, and **every** "Save Settings" click fails — bricking the Configuration tab entirely.

## Fix

Clamp the dropdown value to the valid choice set at construction, defaulting to `1` when stale:

```python
boost_value = self.boost if self.boost in (1, 2) else 1
self.boost_choice = gr.Dropdown(choices=[("ON", 1), ("OFF", 2)], value=boost_value, ...)
```

This mirrors the existing `get_default_value(choices, ui_get(...), default)` clamp pattern already used for other switches in `wgp.py`.

## Verification

- `python -m py_compile plugins/configuration/plugin.py` passes.
- The error signature in #2172 (`Value: 5 is not in the list of choices: [1, 2]`) matches this dropdown's choices exactly.

Tested by: load a `wgp_config.json` with a stale `"boost": 5` → open Configuration → "Save Settings" no longer throws; the dropdown renders with the default ON.
