### PR TITLE
Add a Windows installer and desktop launcher for WanGP

### DIFF
--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -1,0 +1,138 @@
+name: Build Windows installer
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Installer version (x.y.z)"
+        required: false
+        default: ""
+  push:
+    tags:
+      - "launcher-v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Resolve the version number
+        id: version
+        shell: pwsh
+        run: |
+          $version = "${{ github.event.inputs.version }}"
+          if (-not $version) {
+            if ("${{ github.ref }}" -like "refs/tags/launcher-v*") {
+              $version = "${{ github.ref_name }}".Substring("launcher-v".Length)
+            } else {
+              $version = "0.0.$env:GITHUB_RUN_NUMBER"
+            }
+          }
+          if ($version -notmatch '^\d+\.\d+\.\d+$') {
+            throw "Version '$version' must look like 1.2.3"
+          }
+          "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          Write-Host "Building WanGP launcher $version"
+
+      - name: Install the launcher build dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r launcher/requirements-launcher.txt
+
+      - name: Run the launcher unit tests
+        shell: pwsh
+        run: python -m unittest launcher.tests.test_launcher -v
+
+      - name: Stamp the version and the repository into launcher_config.json
+        shell: pwsh
+        run: |
+          $path = "launcher/launcher_config.json"
+          $config = Get-Content $path -Raw | ConvertFrom-Json
+          $config.app_version = "${{ steps.version.outputs.version }}"
+          $config.repo_url = "${{ github.server_url }}/${{ github.repository }}.git"
+          $config | ConvertTo-Json -Depth 10 | Set-Content $path -Encoding UTF8
+          Get-Content $path
+
+      - name: Build the application icon and the executable metadata
+        shell: pwsh
+        run: |
+          python launcher/build_assets.py --version "${{ steps.version.outputs.version }}"
+          if (-not (Test-Path "launcher/assets/wangp.ico")) { throw "Icon generation failed" }
+
+      - name: Freeze the launcher with PyInstaller
+        shell: pwsh
+        run: |
+          pyinstaller launcher/wangp.spec --noconfirm --distpath dist --workpath build/pyinstaller
+          if (-not (Test-Path "dist/launcher-bin/WanGP.exe")) {
+            throw "PyInstaller did not produce dist/launcher-bin/WanGP.exe"
+          }
+
+      - name: Smoke-test the frozen launcher
+        shell: pwsh
+        run: |
+          # The runner has no GPU and no interactive session, so this only asserts
+          # that the bundle loads its modules and resolves its own resources.
+          $process = Start-Process -FilePath "dist/launcher-bin/WanGP.exe" `
+                                   -ArgumentList "--selftest" -PassThru -Wait -NoNewWindow
+          if ($process.ExitCode -ne 0) {
+            throw "Launcher self-test failed with exit code $($process.ExitCode)"
+          }
+
+      - name: Assemble the WanGP payload
+        shell: pwsh
+        run: |
+          # git archive gives us exactly the tracked files: no .git, no caches,
+          # no environment or output folders left over from a previous run.
+          New-Item -ItemType Directory -Force -Path build/payload | Out-Null
+          git archive --format=tar HEAD | tar -x -C build/payload
+          Remove-Item -Recurse -Force build/payload/.github -ErrorAction SilentlyContinue
+          $size = (Get-ChildItem build/payload -Recurse -File | Measure-Object -Property Length -Sum).Sum
+          Write-Host ("Payload: {0:N1} MB" -f ($size / 1MB))
+          if (-not (Test-Path "build/payload/wgp.py")) { throw "wgp.py missing from the payload" }
+          if (-not (Test-Path "build/payload/setup.py")) { throw "setup.py missing from the payload" }
+
+      - name: Install Inno Setup
+        shell: pwsh
+        run: choco install innosetup --no-progress -y
+
+      - name: Compile the installer
+        shell: pwsh
+        run: |
+          $iscc = "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
+          & $iscc `
+            "/DMyAppVersion=${{ steps.version.outputs.version }}" `
+            "/DPayloadDir=$PWD\build\payload" `
+            "/DLauncherDir=$PWD\dist\launcher-bin" `
+            "/DOutputDir=$PWD\dist" `
+            "launcher\installer.iss"
+          if ($LASTEXITCODE -ne 0) { throw "ISCC failed with exit code $LASTEXITCODE" }
+          Get-ChildItem dist/*.exe | ForEach-Object {
+            Write-Host ("{0}  {1:N1} MB" -f $_.Name, ($_.Length / 1MB))
+          }
+
+      - name: Publish the installer as a build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: WanGP-Setup-${{ steps.version.outputs.version }}
+          path: dist/WanGP-Setup-*.exe
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Attach the installer to the release
+        if: startsWith(github.ref, 'refs/tags/launcher-v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/WanGP-Setup-*.exe
+          generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,13 @@ plugins_local.json
 /plugins/wangp-*/
 loras_url_cache.json
 loras_url_cache_v2.json
+
+# --- Windows launcher (launcher/README.md) ---
+# The repository ignores dotfiles and *.html wholesale; re-include the launcher
+# sources and the CI workflow that builds the installer.
+!.github/
+!launcher/web/*.html
+# Generated at build time by launcher/build_assets.py, and PyInstaller output.
+launcher/assets/
+launcher/build/
+launcher/dist/

--- a/launcher/README.md
+++ b/launcher/README.md
@@ -1,0 +1,127 @@
+# WanGP Windows launcher
+
+A small desktop front-end that turns WanGP into a normal Windows application:
+one `WanGP-Setup-x.y.z.exe` to install, a Start-menu shortcut to run, and the
+web UI inside a native window instead of a browser tab.
+
+## Design principle
+
+The launcher owns **no** installation logic. Everything about environments,
+GPU detection, CUDA/ROCm profiles and acceleration kernels already lives in the
+repository's `setup.py`, and the launcher is a graphical façade over it:
+
+| The launcher needs to… | What it actually runs |
+| --- | --- |
+| find the active environment | `python setup.py get_env_info` → `ENV_INFO\|type\|path` |
+| build the environment | `python setup.py install --env venv --auto` |
+| update the code | `python setup.py update` |
+| switch environments | `python setup.py manage` (in a real console) |
+| upgrade Torch/Triton/Sage | `python setup.py upgrade` (in a real console) |
+| start the app | `<env python> wgp.py --server-name 127.0.0.1 --server-port <free port>` |
+
+It also mirrors `scripts/run.bat` where behaviour is observable: extra flags are
+read from `scripts/args.txt`, and exit code `42` means "restart me".
+
+Consequence: `setup.py` stays the single source of truth. A new GPU profile or
+a new kernel added there is picked up by the launcher with no code change here.
+
+## What the user experiences
+
+1. **Install** — `WanGP-Setup.exe`, per-user, no admin prompt. Defaults to
+   `%LOCALAPPDATA%\Programs\WanGP`, and the directory page is left enabled so a
+   roomier drive can be chosen (models need tens of GB). The installer adds the
+   Microsoft Edge WebView2 Runtime if Windows does not already have it.
+2. **First launch** — a progress window with a live console:
+   Python 3.11 is installed if missing (per-user, including the `py` launcher),
+   a private copy of Git is unpacked if missing, then `setup.py --auto` detects
+   the GPU and builds the environment.
+3. **Every launch after that** — `wgp.py` starts on a free local port, the
+   launcher waits for the port to answer, then swaps the progress page for the
+   WanGP interface. A menu bar exposes Update, Repair, environment management
+   and the installation / outputs / logs folders.
+
+## Layout
+
+```
+launcher/
+  main.py              entry point; --selftest verifies a frozen build
+  config.py            paths, bundled configuration, logging
+  process.py           windowless subprocesses, line streaming, process trees
+  prereqs.py           Python 3.11 and Git detection plus unattended install
+  environment.py       the setup.py bridge and args.txt handling
+  server.py            runs wgp.py, waits for readiness, honours exit code 42
+  ui.py                pywebview window, menu bar, JS bridge
+  web/setup.html       the progress / console page
+  build_assets.py      generates the .ico and the EXE version resource
+  wangp.spec           PyInstaller one-folder bundle → launcher-bin/
+  installer.iss        Inno Setup script → WanGP-Setup-x.y.z.exe
+  tests/               offline tests, no GPU and no pywebview required
+```
+
+Runtime state lives outside the installation directory, in
+`%LOCALAPPDATA%\WanGP`: `logs/launcher.log`, `logs/wangp-server.log`,
+`downloads/` (cached Python and Git installers) and `tools/git` when a private
+Git was needed.
+
+## Building
+
+CI does this on every tag `launcher-v*` and on demand via **Actions → Build
+Windows installer**; the installer lands as a build artifact and, for a tag, on
+the release. To reproduce it locally on a Windows machine:
+
+```powershell
+python -m pip install -r launcher\requirements-launcher.txt
+python -m unittest launcher.tests.test_launcher -v
+python launcher\build_assets.py --version 1.0.0
+pyinstaller launcher\wangp.spec --noconfirm --distpath dist --workpath build\pyinstaller
+
+# Payload = the tracked files only, so no caches or environments leak in.
+mkdir build\payload
+git archive --format=tar HEAD | tar -x -C build\payload
+
+& "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" `
+    /DMyAppVersion=1.0.0 /DPayloadDir="$PWD\build\payload" `
+    /DLauncherDir="$PWD\dist\launcher-bin" /DOutputDir="$PWD\dist" `
+    launcher\installer.iss
+```
+
+Run it unfrozen during development — same behaviour, no packaging step:
+
+```powershell
+python launcher\main.py
+```
+
+## Configuration
+
+`launcher_config.json` is bundled into the executable and can be overridden by a
+file of the same name placed next to the installed launcher. CI stamps
+`app_version` and `repo_url` at build time. Useful keys:
+
+| Key | Purpose |
+| --- | --- |
+| `repo_url`, `repo_branch` | remote used to attach the install to git for updates |
+| `python.installer_url`, `python.installer_sha256` | the Python bootstrap; set the checksum to pin it |
+| `git.portable_url`, `git.portable_sha256` | the portable Git bootstrap |
+| `env_type` | `venv` (default), `uv`, `conda` or `none` |
+| `server.preferred_port` | tried first; a free port is chosen if it is busy |
+| `server.startup_timeout_seconds` | how long to wait for the web UI on a cold start |
+
+## Notes and limits
+
+- **Updates.** The installer ships the tracked sources without a `.git`
+  directory, so the first update attaches the tree to `repo_url` itself instead
+  of relying on `setup.py`'s repair path, which hardcodes the upstream
+  repository in its `git remote add origin`. Setting `origin` first also makes
+  that path harmless if it ever runs: `git remote add` fails on an existing
+  remote and `setup.py` ignores the error, so the fork's remote survives. After
+  that, `setup.py update` handles the usual `git pull` plus requirements
+  refresh.
+- **Uninstalling** never deletes the environment, models or generated media on
+  its own: it asks, and keeping them is the default answer.
+- **Windows only.** `setup.py` builds its environment with `py -3.11 -m venv`
+  on Windows, so the Python launcher is a hard prerequisite; that is why the
+  launcher installs Python itself when `py -3.11` does not resolve.
+- **Not covered by the offline tests:** the WebView2 window, the Inno Setup
+  flow and the unattended Python install. The build workflow runs the frozen
+  executable with `--selftest` to catch packaging mistakes, but the installer
+  itself still needs a manual pass on a real Windows machine before a release.

--- a/launcher/__init__.py
+++ b/launcher/__init__.py
@@ -1,0 +1,3 @@
+"""Windows launcher for WanGP: a thin graphical front-end over setup.py."""
+
+__all__ = ["config", "environment", "prereqs", "process", "server", "ui"]

--- a/launcher/build_assets.py
+++ b/launcher/build_assets.py
@@ -1,0 +1,100 @@
+"""Generate the build-time assets for the Windows launcher.
+
+Produces the multi-resolution application icon from the repository favicon and
+the VERSIONINFO resource PyInstaller stamps into WanGP.exe. Run from CI, or by
+hand before building the spec locally.
+"""
+
+import argparse
+import os
+import sys
+
+ICON_SIZES = (16, 24, 32, 48, 64, 128, 256)
+
+VERSION_INFO_TEMPLATE = """VSVersionInfo(
+  ffi=FixedFileInfo(
+    filevers=({tuple}),
+    prodvers=({tuple}),
+    mask=0x3f,
+    flags=0x0,
+    OS=0x40004,
+    fileType=0x1,
+    subtype=0x0,
+    date=(0, 0)
+  ),
+  kids=[
+    StringFileInfo([
+      StringTable(
+        '040904B0',
+        [StringStruct('CompanyName', {publisher!r}),
+         StringStruct('FileDescription', 'WanGP Launcher'),
+         StringStruct('FileVersion', {version!r}),
+         StringStruct('InternalName', 'WanGP'),
+         StringStruct('LegalCopyright', ''),
+         StringStruct('OriginalFilename', 'WanGP.exe'),
+         StringStruct('ProductName', 'WanGP'),
+         StringStruct('ProductVersion', {version!r})])
+    ]),
+    VarFileInfo([VarStruct('Translation', [1033, 1200])])
+  ]
+)
+"""
+
+
+def build_icon(source, destination):
+    from PIL import Image
+
+    image = Image.open(source).convert("RGBA")
+    width, height = image.size
+    if width != height:
+        # Pad to a square so Windows never stretches the icon.
+        side = max(width, height)
+        square = Image.new("RGBA", (side, side), (0, 0, 0, 0))
+        square.paste(image, ((side - width) // 2, (side - height) // 2))
+        image = square
+
+    # Pillow silently drops any requested size larger than the source, which
+    # would leave the icon without its 128 and 256 px variants.
+    largest = max(ICON_SIZES)
+    if image.size[0] < largest:
+        image = image.resize((largest, largest), Image.LANCZOS)
+
+    image.save(destination, format="ICO", sizes=[(size, size) for size in ICON_SIZES])
+    return destination
+
+
+def build_version_info(version, publisher, destination):
+    parts = version.split(".")
+    if len(parts) != 3 or not all(part.isdigit() for part in parts):
+        raise SystemExit(f"Version '{version}' must look like 1.2.3")
+    version_tuple = ", ".join(parts + ["0"])
+    with open(destination, "w", encoding="utf-8") as handle:
+        handle.write(
+            VERSION_INFO_TEMPLATE.format(tuple=version_tuple, version=version, publisher=publisher)
+        )
+    return destination
+
+
+def main(argv=None):
+    here = os.path.dirname(os.path.abspath(__file__))
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", default="0.0.0", help="Installer version, x.y.z")
+    parser.add_argument("--publisher", default="Blencia")
+    parser.add_argument(
+        "--icon-source",
+        default=os.path.join(os.path.dirname(here), "favicon.png"),
+        help="PNG used as the application icon",
+    )
+    parser.add_argument("--outdir", default=os.path.join(here, "assets"))
+    args = parser.parse_args(argv)
+
+    os.makedirs(args.outdir, exist_ok=True)
+    icon = build_icon(args.icon_source, os.path.join(args.outdir, "wangp.ico"))
+    info = build_version_info(args.version, args.publisher, os.path.join(args.outdir, "version_info.txt"))
+    print(f"wrote {icon}")
+    print(f"wrote {info}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/launcher/config.py
+++ b/launcher/config.py
@@ -1,0 +1,155 @@
+"""Paths, bundled configuration and logging for the WanGP Windows launcher.
+
+The launcher never duplicates installation logic: it is a graphical front-end
+over the repository's own ``setup.py``. This module only resolves *where*
+things live and how we talk to the user about it.
+"""
+
+import json
+import logging
+import os
+import sys
+
+APP_DIR_NAME = "WanGP"
+
+_DEFAULTS = {
+    "app_name": "WanGP",
+    "app_version": "1.0.0",
+    "publisher": "Blencia",
+    "repo_url": "https://github.com/blencia/Wan2Gplus.git",
+    "repo_branch": "main",
+    "python": {
+        "series": "3.11",
+        "installer_url": "https://www.python.org/ftp/python/3.11.9/python-3.11.9-amd64.exe",
+        "installer_sha256": "",
+        "label": "Python 3.11.9 (64-bit)",
+    },
+    "git": {"portable_url": "", "portable_sha256": "", "label": "Portable Git"},
+    "env_type": "venv",
+    "server": {"host": "127.0.0.1", "preferred_port": 7860, "startup_timeout_seconds": 900},
+    "window": {"width": 1450, "height": 940, "min_width": 900, "min_height": 620},
+}
+
+
+def is_frozen():
+    return getattr(sys, "frozen", False)
+
+
+def bundle_dir():
+    """Directory holding read-only resources shipped inside the executable."""
+    if is_frozen():
+        return getattr(sys, "_MEIPASS", os.path.dirname(sys.executable))
+    return os.path.dirname(os.path.abspath(__file__))
+
+
+_CHECKOUT_MARKERS = ("wgp.py", "setup.py")
+
+
+def _looks_like_checkout(path):
+    return all(os.path.isfile(os.path.join(path, name)) for name in _CHECKOUT_MARKERS)
+
+
+def install_root():
+    """The WanGP checkout: where wgp.py, setup.py and requirements.txt live.
+
+    Frozen, the executable ships in a ``launcher-bin`` subfolder of the
+    installation directory, so we walk up until the checkout markers appear.
+    From source, the launcher runs out of ``launcher/`` inside the repository.
+    """
+    if not is_frozen():
+        return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+    start = os.path.dirname(os.path.abspath(sys.executable))
+    current = start
+    for _ in range(4):
+        if _looks_like_checkout(current):
+            return current
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+    return start
+
+
+def _deep_merge(base, override):
+    merged = dict(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def load_config():
+    """Bundled defaults, overridable by a JSON file next to the executable."""
+    config = dict(_DEFAULTS)
+    for candidate in (
+        os.path.join(bundle_dir(), "launcher_config.json"),
+        os.path.join(install_root(), "launcher_config.json"),
+    ):
+        if not os.path.isfile(candidate):
+            continue
+        try:
+            with open(candidate, "r", encoding="utf-8") as handle:
+                config = _deep_merge(config, json.load(handle))
+        except (OSError, ValueError) as exc:
+            logging.getLogger(__name__).warning("Ignoring %s: %s", candidate, exc)
+    return config
+
+
+def data_dir():
+    """Writable per-user directory for logs and launcher state."""
+    base = os.environ.get("LOCALAPPDATA") or os.path.expanduser("~")
+    path = os.path.join(base, APP_DIR_NAME)
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def logs_dir():
+    path = os.path.join(data_dir(), "logs")
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def tools_dir():
+    """Where we drop self-contained tools (portable Git) we install ourselves."""
+    path = os.path.join(data_dir(), "tools")
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def state_file():
+    return os.path.join(data_dir(), "launcher_state.json")
+
+
+def read_state():
+    try:
+        with open(state_file(), "r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except (OSError, ValueError):
+        return {}
+
+
+def write_state(**updates):
+    state = read_state()
+    state.update(updates)
+    try:
+        with open(state_file(), "w", encoding="utf-8") as handle:
+            json.dump(state, handle, indent=2)
+    except OSError as exc:
+        logging.getLogger(__name__).warning("Could not persist launcher state: %s", exc)
+
+
+def setup_logging():
+    log_path = os.path.join(logs_dir(), "launcher.log")
+    handlers = [logging.FileHandler(log_path, encoding="utf-8")]
+    if sys.stderr is not None:
+        handlers.append(logging.StreamHandler(sys.stderr))
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)-7s %(name)s: %(message)s",
+        handlers=handlers,
+        force=True,
+    )
+    return log_path

--- a/launcher/environment.py
+++ b/launcher/environment.py
@@ -1,0 +1,205 @@
+"""Drive the repository's own setup.py from the launcher.
+
+Everything about creating environments, picking a CUDA/ROCm profile and
+installing acceleration kernels already lives in setup.py. The launcher only
+calls it and mirrors run.bat's rules for resolving the active environment.
+"""
+
+import logging
+import os
+
+from . import process
+
+LOGGER = logging.getLogger(__name__)
+
+SETUP_SCRIPT = "setup.py"
+MAIN_SCRIPT = "wgp.py"
+ENVS_FILE = "envs.json"
+
+
+class EnvironmentError_(RuntimeError):
+    """Raised when the WanGP environment cannot be resolved or built."""
+
+
+def is_wangp_checkout(root):
+    return all(os.path.isfile(os.path.join(root, name)) for name in (SETUP_SCRIPT, MAIN_SCRIPT))
+
+
+def has_environment(root):
+    return os.path.isfile(os.path.join(root, ENVS_FILE))
+
+
+def get_env_info(root, python_exe):
+    """Ask setup.py which environment is active.
+
+    Mirrors run.bat: setup.py prints ``ENV_INFO|<type>|<path>`` and exits
+    non-zero when nothing is configured yet.
+    """
+    code, out = process.run_quiet([python_exe, SETUP_SCRIPT, "get_env_info"], cwd=root, timeout=120)
+    if code != 0:
+        return None
+    for line in out.splitlines():
+        parts = line.strip().split("|")
+        if len(parts) == 3 and parts[0] == "ENV_INFO":
+            env_type, env_path = parts[1], parts[2]
+            LOGGER.info("Active environment: type=%s path=%s", env_type, env_path)
+            return env_type, env_path
+    return None
+
+
+def env_python(root, env_type, env_path, fallback):
+    """Interpreter for an environment, matching setup.py's ENV_TEMPLATES."""
+    if env_type == "none" or not env_path:
+        return fallback
+    absolute = env_path if os.path.isabs(env_path) else os.path.normpath(os.path.join(root, env_path))
+    if env_type == "conda":
+        candidate = os.path.join(absolute, "python.exe")
+    else:  # venv and uv both use the standard Scripts layout on Windows
+        candidate = os.path.join(absolute, "Scripts", "python.exe")
+    if os.path.isfile(candidate):
+        return candidate
+    raise EnvironmentError_(
+        f"The active environment '{env_path}' has no interpreter at {candidate}.\n"
+        "Use 'Repair / reinstall' to rebuild it."
+    )
+
+
+def resolve_runtime_python(root, system_python):
+    """Return the interpreter that should run wgp.py, or None if not installed."""
+    info = get_env_info(root, system_python)
+    if info is None:
+        return None
+    return env_python(root, info[0], info[1], system_python)
+
+
+def install_auto(root, python_exe, env_type, on_line, env=None, cancelled=None):
+    """Run setup.py's one-click install: detects the GPU and builds the env."""
+    on_line(f"[*] Building the '{env_type}' environment with setup.py --auto")
+    on_line("[*] This downloads PyTorch and the acceleration kernels; expect a long first run.")
+    code = process.stream(
+        [python_exe, SETUP_SCRIPT, "install", "--env", env_type, "--auto"],
+        on_line=on_line,
+        cwd=root,
+        env=env or process.child_env(),
+        cancelled=cancelled,
+    )
+    if code == -1:
+        raise EnvironmentError_("Installation cancelled.")
+    if code != 0:
+        raise EnvironmentError_(
+            f"setup.py install failed with exit code {code}. See the log for the failing command."
+        )
+    on_line("[*] Environment ready.")
+
+
+def bootstrap_git_repo(root, git_exe, repo_url, branch, on_line, env=None):
+    """Attach the installed tree to its git remote so updates can work.
+
+    The installer ships the source without a .git directory. setup.py's own
+    repair path hardcodes the upstream repository, so we wire up this fork's
+    remote ourselves before handing over to setup.py update.
+    """
+    if os.path.isdir(os.path.join(root, ".git")):
+        return True
+    if not git_exe:
+        on_line("[!] Git is not available, so the code cannot be updated.")
+        return False
+
+    env = env or process.child_env()
+    on_line(f"[*] Linking this installation to {repo_url} ({branch}) ...")
+    steps = [
+        [git_exe, "init"],
+        [git_exe, "remote", "add", "origin", repo_url],
+        [git_exe, "fetch", "--depth", "1", "origin", branch],
+        [git_exe, "reset", "--mixed", f"origin/{branch}"],
+        [git_exe, "checkout", "-B", branch],
+        [git_exe, "branch", f"--set-upstream-to=origin/{branch}", branch],
+    ]
+    for step in steps:
+        code = process.stream(step, on_line=on_line, cwd=root, env=env)
+        if code != 0 and step[1] not in ("remote", "branch"):
+            on_line(f"[!] '{' '.join(step[1:])}' failed with exit code {code}.")
+            return False
+    on_line("[*] Repository linked.")
+    return True
+
+
+def update(root, python_exe, on_line, env=None, cancelled=None):
+    """Run setup.py update: git pull plus a requirements refresh when needed."""
+    code = process.stream(
+        [python_exe, SETUP_SCRIPT, "update"],
+        on_line=on_line,
+        cwd=root,
+        env=env or process.child_env(),
+        cancelled=cancelled,
+    )
+    if code == -1:
+        raise EnvironmentError_("Update cancelled.")
+    if code != 0:
+        raise EnvironmentError_(f"setup.py update failed with exit code {code}.")
+    on_line("[*] Update finished.")
+
+
+def open_manage_console(root, python_exe, env=None):
+    """Hand the user setup.py's interactive environment manager in a console."""
+    return process.popen(
+        ["cmd", "/k", f'"{python_exe}" {SETUP_SCRIPT} manage'],
+        cwd=root,
+        env=env or process.child_env(),
+        visible_console=True,
+        capture=False,
+    )
+
+
+def open_upgrade_console(root, python_exe, env=None):
+    """setup.py upgrade is a menu-driven flow; it belongs in a real console."""
+    return process.popen(
+        ["cmd", "/k", f'"{python_exe}" {SETUP_SCRIPT} upgrade'],
+        cwd=root,
+        env=env or process.child_env(),
+        visible_console=True,
+        capture=False,
+    )
+
+
+def read_extra_args(root):
+    """Honour scripts/args.txt exactly like run.bat does, minus browser flags.
+
+    ``--open-browser`` would pop an external browser next to our own window,
+    and the server host/port are ours to decide, so those are filtered out.
+    """
+    path = os.path.join(root, "scripts", "args.txt")
+    if not os.path.isfile(path):
+        return []
+
+    tokens = []
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as handle:
+            for raw in handle:
+                line = raw.strip()
+                if not line or line.startswith("#"):
+                    continue
+                tokens.extend(line.split())
+    except OSError as exc:
+        LOGGER.warning("Could not read %s: %s", path, exc)
+        return []
+
+    dropped_flags = {"--open-browser", "--share", "--listen"}
+    dropped_options = {"--server-port", "--server-name"}
+    cleaned = []
+    skip_next = False
+    for token in tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        if token in dropped_flags:
+            LOGGER.info("Ignoring %s from args.txt: the launcher owns the window", token)
+            continue
+        if token in dropped_options:
+            LOGGER.info("Ignoring %s from args.txt: the launcher owns the server address", token)
+            skip_next = True
+            continue
+        if token.split("=", 1)[0] in dropped_options:
+            continue
+        cleaned.append(token)
+    return cleaned

--- a/launcher/installer.iss
+++ b/launcher/installer.iss
@@ -1,0 +1,166 @@
+; Inno Setup script for the WanGP Windows installer.
+;
+; Compile with (values are supplied by the CI workflow):
+;   iscc /DMyAppVersion=1.0.0 /DPayloadDir=..\build\payload ^
+;        /DLauncherDir=..\dist\launcher-bin /DOutputDir=..\dist installer.iss
+
+#ifndef MyAppVersion
+  #define MyAppVersion "1.0.0"
+#endif
+#ifndef PayloadDir
+  #define PayloadDir "..\build\payload"
+#endif
+#ifndef LauncherDir
+  #define LauncherDir "..\dist\launcher-bin"
+#endif
+#ifndef OutputDir
+  #define OutputDir "..\dist"
+#endif
+
+#define MyAppName "WanGP"
+#define MyAppPublisher "Blencia"
+#define MyAppURL "https://github.com/blencia/Wan2Gplus"
+#define MyAppExeName "WanGP.exe"
+
+[Setup]
+; Keep this GUID stable: it is how Windows recognises upgrades of this app.
+AppId={{7C5E1A54-9B2D-4F0A-9E33-2D6F1B4C8A71}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}/issues
+AppUpdatesURL={#MyAppURL}/releases
+VersionInfoVersion={#MyAppVersion}
+
+; Per-user install: no UAC prompt, and the app can write into its own folder,
+; which matters because WanGP downloads models next to itself.
+PrivilegesRequired=lowest
+PrivilegesRequiredOverridesAllowed=dialog
+DefaultDirName={localappdata}\Programs\{#MyAppName}
+DefaultGroupName={#MyAppName}
+DisableProgramGroupPage=yes
+DisableDirPage=no
+AllowNoIcons=yes
+
+OutputDir={#OutputDir}
+OutputBaseFilename=WanGP-Setup-{#MyAppVersion}
+SetupIconFile=assets\wangp.ico
+WizardStyle=modern
+Compression=lzma2/max
+SolidCompression=yes
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+UninstallDisplayIcon={app}\launcher-bin\{#MyAppExeName}
+CloseApplications=yes
+RestartApplications=no
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+Name: "french"; MessagesFile: "compiler:Languages\French.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[Files]
+; The launcher bundle.
+Source: "{#LauncherDir}\*"; DestDir: "{app}\launcher-bin"; Flags: ignoreversion recursesubdirs createallsubdirs
+; The WanGP source tree (CI strips .git, caches, environments and outputs).
+Source: "{#PayloadDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\{#MyAppName}"; Filename: "{app}\launcher-bin\{#MyAppExeName}"; WorkingDir: "{app}"
+Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\launcher-bin\{#MyAppExeName}"; WorkingDir: "{app}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\launcher-bin\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#MyAppName}}"; Flags: nowait postinstall skipifsilent
+
+[UninstallDelete]
+; Python bytecode caches are generated after install, so Inno does not track them.
+Type: filesandordirs; Name: "{app}\__pycache__"
+
+[Messages]
+english.WelcomeLabel2=This will install [name/ver] on your computer.%n%nWanGP downloads its Python environment and its AI models on first launch. Plan for at least 40 GB of free space on the drive you install to, and pick a drive with room to spare.
+french.WelcomeLabel2=Ceci va installer [name/ver] sur votre ordinateur.%n%nWanGP télécharge son environnement Python et ses modèles d'IA au premier lancement. Prévoyez au moins 40 Go d'espace libre sur le disque choisi.
+
+[Code]
+var
+  DownloadPage: TDownloadWizardPage;
+  NeedsWebView2: Boolean;
+
+function WebView2Installed(): Boolean;
+var
+  Version: String;
+begin
+  { The Evergreen runtime registers its version under the WebView2 client GUID. }
+  Result :=
+    RegQueryStringValue(HKLM, 'SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}', 'pv', Version) or
+    RegQueryStringValue(HKLM, 'SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}', 'pv', Version) or
+    RegQueryStringValue(HKCU, 'SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}', 'pv', Version);
+  if Result then
+    Result := (Version <> '') and (Version <> '0.0.0.0');
+end;
+
+function OnDownloadProgress(const Url, FileName: String; const Progress, ProgressMax: Int64): Boolean;
+begin
+  Result := True;
+end;
+
+procedure InitializeWizard();
+begin
+  DownloadPage := CreateDownloadPage(SetupMessage(msgWizardPreparing), SetupMessage(msgPreparingDesc), @OnDownloadProgress);
+  NeedsWebView2 := not WebView2Installed();
+end;
+
+function NextButtonClick(CurPageID: Integer): Boolean;
+var
+  ResultCode: Integer;
+begin
+  Result := True;
+  if (CurPageID = wpReady) and NeedsWebView2 then
+  begin
+    { WanGP's window is a WebView2 control; Windows 10 may not ship one. }
+    DownloadPage.Clear;
+    DownloadPage.Add('https://go.microsoft.com/fwlink/p/?LinkId=2124703', 'MicrosoftEdgeWebview2Setup.exe', '');
+    DownloadPage.Show;
+    try
+      try
+        DownloadPage.Download;
+        if not Exec(ExpandConstant('{tmp}\MicrosoftEdgeWebview2Setup.exe'), '/silent /install', '',
+                    SW_SHOW, ewWaitUntilTerminated, ResultCode) or (ResultCode <> 0) then
+          MsgBox('The Microsoft Edge WebView2 Runtime could not be installed automatically.' + #13#10 +
+                 'WanGP will install anyway, but its window may fail to open until you install WebView2 manually.',
+                 mbInformation, MB_OK);
+      except
+        MsgBox('The Microsoft Edge WebView2 Runtime could not be downloaded.' + #13#10 +
+               'Setup will continue; install WebView2 manually if the WanGP window does not open.',
+               mbInformation, MB_OK);
+      end;
+    finally
+      DownloadPage.Hide;
+    end;
+  end;
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+var
+  AppDir: String;
+begin
+  if CurUninstallStep = usPostUninstall then
+  begin
+    AppDir := ExpandConstant('{app}');
+    { The Python environment, model weights and generated media are created
+      after installation, so Inno never tracks them. Removing tens of GB
+      silently would be hostile: ask, and default to keeping them. }
+    if DirExists(AppDir) then
+    begin
+      if MsgBox('Also delete the Python environment, the downloaded models and everything else in:' + #13#10 +
+                AppDir + #13#10#13#10 +
+                'This can free tens of GB and includes your generated videos and images.' + #13#10 +
+                'Choose No to keep that folder.',
+                mbConfirmation, MB_YESNO or MB_DEFBUTTON2) = IDYES then
+        DelTree(AppDir, True, True, True);
+    end;
+  end;
+end;

--- a/launcher/launcher_config.json
+++ b/launcher/launcher_config.json
@@ -1,0 +1,30 @@
+{
+    "app_name": "WanGP",
+    "app_version": "1.0.0",
+    "publisher": "Blencia",
+    "repo_url": "https://github.com/blencia/Wan2Gplus.git",
+    "repo_branch": "main",
+    "python": {
+        "series": "3.11",
+        "installer_url": "https://www.python.org/ftp/python/3.11.9/python-3.11.9-amd64.exe",
+        "installer_sha256": "",
+        "label": "Python 3.11.9 (64-bit)"
+    },
+    "git": {
+        "portable_url": "https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.1/PortableGit-2.47.1-64-bit.7z.exe",
+        "portable_sha256": "",
+        "label": "Portable Git 2.47.1"
+    },
+    "env_type": "venv",
+    "server": {
+        "host": "127.0.0.1",
+        "preferred_port": 7860,
+        "startup_timeout_seconds": 900
+    },
+    "window": {
+        "width": 1450,
+        "height": 940,
+        "min_width": 900,
+        "min_height": 620
+    }
+}

--- a/launcher/main.py
+++ b/launcher/main.py
@@ -1,0 +1,121 @@
+"""Entry point for the WanGP Windows launcher."""
+
+import ctypes
+import logging
+import os
+import sys
+
+if __package__ in (None, ""):
+    # Allow "python launcher/main.py" during development.
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from launcher import config  # noqa: E402  (path bootstrap must come first)
+
+
+def _enable_dpi_awareness():
+    """Keep the WanGP UI crisp on scaled displays."""
+    if os.name != "nt":
+        return
+    try:
+        ctypes.windll.shcore.SetProcessDpiAwareness(2)  # per-monitor aware
+    except (AttributeError, OSError):
+        try:
+            ctypes.windll.user32.SetProcessDPIAware()
+        except (AttributeError, OSError):
+            pass
+
+
+def _fatal(message):
+    logging.getLogger(__name__).error("%s", message)
+    if os.name == "nt":
+        try:
+            ctypes.windll.user32.MessageBoxW(None, message, "WanGP", 0x10)
+        except (AttributeError, OSError):
+            pass
+    else:
+        print(message, file=sys.stderr)
+
+
+def _selftest():
+    """Verify a frozen build can find its resources and its window backend.
+
+    Runs headless in CI, where there is no GPU and no interactive session, so
+    it deliberately stops short of creating a window.
+    """
+    logger = logging.getLogger(__name__)
+    checks = []
+
+    cfg = config.load_config()
+    checks.append(("config loaded", bool(cfg.get("app_name"))))
+    checks.append(("version stamped", cfg.get("app_version", "") != ""))
+
+    page = os.path.join(config.bundle_dir(), "web", "setup.html")
+    checks.append(("setup page bundled", os.path.isfile(page)))
+
+    try:
+        import webview  # noqa: F401  (import is the check)
+        from webview.platforms import edgechromium  # noqa: F401
+
+        checks.append(("webview + edgechromium importable", True))
+    except ImportError as exc:
+        logger.error("webview import failed: %s", exc)
+        checks.append(("webview + edgechromium importable", False))
+
+    try:
+        from launcher import environment, prereqs, process, server, ui  # noqa: F401
+
+        checks.append(("launcher modules importable", True))
+    except ImportError as exc:
+        logger.error("launcher import failed: %s", exc)
+        checks.append(("launcher modules importable", False))
+
+    checks.append(("writable data dir", os.path.isdir(config.data_dir())))
+
+    for name, passed in checks:
+        logger.info("selftest %-38s %s", name, "OK" if passed else "FAILED")
+    failures = [name for name, passed in checks if not passed]
+    if failures:
+        logger.error("selftest failures: %s", ", ".join(failures))
+        return 1
+    logger.info("selftest passed")
+    return 0
+
+
+def main():
+    log_path = config.setup_logging()
+    logger = logging.getLogger(__name__)
+    cfg = config.load_config()
+    logger.info(
+        "%s launcher %s starting (root=%s, log=%s)",
+        cfg.get("app_name", "WanGP"),
+        cfg.get("app_version", "?"),
+        config.install_root(),
+        log_path,
+    )
+    if "--selftest" in sys.argv[1:]:
+        return _selftest()
+
+    _enable_dpi_awareness()
+
+    try:
+        # Imported here, not at module scope, so a missing WebView2 backend is
+        # reported in a message box instead of a bare import traceback.
+        from launcher import ui
+
+        ui.run(cfg)
+    except ImportError as exc:
+        _fatal(
+            "The launcher could not start its window component.\n\n"
+            f"{exc}\n\n"
+            "Reinstall WanGP, or install the Microsoft Edge WebView2 Runtime."
+        )
+        return 2
+    except Exception as exc:  # last resort: never die without telling the user
+        logger.exception("Launcher crashed")
+        _fatal(f"WanGP failed to start:\n\n{exc}\n\nDetails: {log_path}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/launcher/prereqs.py
+++ b/launcher/prereqs.py
@@ -1,0 +1,187 @@
+"""Detect and, when missing, install what WanGP needs before setup.py can run.
+
+setup.py builds its virtual environment with ``py -3.11 -m venv`` on Windows,
+so the real prerequisite is the Python launcher *plus* a 3.11 interpreter --
+not merely "some Python". Git is only needed to update an existing install, so
+a missing Git is reported but never fatal.
+"""
+
+import hashlib
+import logging
+import os
+import shutil
+import urllib.request
+
+from . import config, process
+
+LOGGER = logging.getLogger(__name__)
+
+_DOWNLOAD_CHUNK = 256 * 1024
+
+
+class PrereqError(RuntimeError):
+    pass
+
+
+def _report(on_line, message):
+    LOGGER.info(message)
+    if on_line is not None:
+        on_line(message)
+
+
+def download(url, destination, on_line=None, expected_sha256=""):
+    _report(on_line, f"[*] Downloading {os.path.basename(destination)} ...")
+    os.makedirs(os.path.dirname(destination), exist_ok=True)
+    partial = destination + ".part"
+    digest = hashlib.sha256()
+    last_percent = -5
+    request = urllib.request.Request(url, headers={"User-Agent": "WanGP-Launcher"})
+    with urllib.request.urlopen(request, timeout=60) as response:  # noqa: S310 - fixed https URLs
+        total = int(response.headers.get("Content-Length") or 0)
+        read = 0
+        with open(partial, "wb") as handle:
+            while True:
+                chunk = response.read(_DOWNLOAD_CHUNK)
+                if not chunk:
+                    break
+                handle.write(chunk)
+                digest.update(chunk)
+                read += len(chunk)
+                if total:
+                    percent = int(read * 100 / total)
+                    if percent >= last_percent + 5:
+                        last_percent = percent
+                        _report(on_line, f"    {percent}%  ({read // 1048576} / {total // 1048576} MB)")
+
+    if expected_sha256:
+        actual = digest.hexdigest()
+        if actual.lower() != expected_sha256.lower():
+            os.remove(partial)
+            raise PrereqError(
+                f"Checksum mismatch for {url}\n  expected {expected_sha256}\n  got      {actual}"
+            )
+        _report(on_line, "    checksum verified")
+
+    os.replace(partial, destination)
+    return destination
+
+
+def _python_launcher_ok(series):
+    code, out = process.run_quiet(["py", f"-{series}", "-c", "import sys; print(sys.executable)"])
+    if code == 0 and out:
+        return out.splitlines()[-1].strip()
+    return None
+
+
+def find_python(series="3.11"):
+    """Return the path of the interpreter ``py -<series>`` resolves to."""
+    found = _python_launcher_ok(series)
+    if found:
+        LOGGER.info("Python %s available via the py launcher: %s", series, found)
+    return found
+
+
+def python_present_but_unlaunchable(series="3.11"):
+    """A 3.11 install that ``py`` cannot see -- the launcher itself is missing."""
+    compact = series.replace(".", "")
+    candidates = [
+        os.path.join(os.environ.get("LOCALAPPDATA", ""), "Programs", "Python", f"Python{compact}", "python.exe"),
+        os.path.join(os.environ.get("PROGRAMFILES", ""), f"Python{compact}", "python.exe"),
+        os.path.join("C:\\", f"Python{compact}", "python.exe"),
+    ]
+    return next((path for path in candidates if path and os.path.isfile(path)), None)
+
+
+def install_python(cfg, on_line=None):
+    """Install Python for the current user, including the py launcher."""
+    spec = cfg["python"]
+    url = spec.get("installer_url")
+    if not url:
+        raise PrereqError("No Python installer URL is configured.")
+
+    installer = os.path.join(config.data_dir(), "downloads", os.path.basename(url))
+    if not os.path.isfile(installer):
+        download(url, installer, on_line=on_line, expected_sha256=spec.get("installer_sha256", ""))
+    else:
+        _report(on_line, f"[*] Reusing cached installer: {installer}")
+
+    _report(on_line, f"[*] Installing {spec.get('label', 'Python')} (per-user, no admin rights needed) ...")
+    _report(on_line, "    the Python setup window will show its own progress bar")
+    code = process.stream(
+        [
+            installer,
+            "/passive",
+            "InstallAllUsers=0",
+            "PrependPath=1",
+            "Include_launcher=1",
+            "Include_pip=1",
+            "Include_test=0",
+            "AssociateFiles=0",
+            "Shortcuts=0",
+        ],
+        on_line=on_line if on_line is not None else (lambda _line: None),
+        env=process.child_env(),
+    )
+
+    # 0 = success, 3010 = success but a reboot is pending, 1602 = user cancelled.
+    if code == 1602:
+        raise PrereqError("Python installation was cancelled.")
+    if code not in (0, 3010):
+        raise PrereqError(f"The Python installer failed with exit code {code}.")
+
+    found = find_python(spec.get("series", "3.11"))
+    if not found:
+        raise PrereqError(
+            "Python was installed but the 'py' launcher still cannot find it.\n"
+            "Sign out and back in (or reboot) and start WanGP again."
+        )
+    _report(on_line, f"[*] Python ready: {found}")
+    return found
+
+
+def portable_git_exe():
+    path = os.path.join(config.tools_dir(), "git", "cmd", "git.exe")
+    return path if os.path.isfile(path) else None
+
+
+def find_git():
+    """Return a usable git.exe: the system one first, then our portable copy."""
+    system_git = shutil.which("git")
+    if system_git:
+        return system_git
+    return portable_git_exe()
+
+
+def install_portable_git(cfg, on_line=None):
+    """Unpack Git for Windows into our tools folder -- self-contained, no admin."""
+    spec = cfg.get("git", {})
+    url = spec.get("portable_url")
+    if not url:
+        raise PrereqError("No portable Git URL is configured.")
+
+    archive = os.path.join(config.data_dir(), "downloads", os.path.basename(url))
+    if not os.path.isfile(archive):
+        download(url, archive, on_line=on_line, expected_sha256=spec.get("portable_sha256", ""))
+
+    target = os.path.join(config.tools_dir(), "git")
+    _report(on_line, f"[*] Extracting {spec.get('label', 'portable Git')} to {target} ...")
+    os.makedirs(target, exist_ok=True)
+    # The PortableGit download is a 7-Zip self-extracting archive.
+    code, out = process.run_quiet([archive, "-o" + target, "-y"], timeout=1800)
+    if code != 0:
+        raise PrereqError(f"Could not extract portable Git (exit {code}).\n{out}")
+
+    git_exe = portable_git_exe()
+    if not git_exe:
+        raise PrereqError("Portable Git was extracted but git.exe is missing.")
+    _report(on_line, f"[*] Git ready: {git_exe}")
+    return git_exe
+
+
+def env_with_git(git_exe, extra=None):
+    """Child environment with the resolved git.exe reachable on PATH."""
+    env = process.child_env(extra)
+    if git_exe:
+        git_dir = os.path.dirname(git_exe)
+        env["PATH"] = git_dir + os.pathsep + env.get("PATH", "")
+    return env

--- a/launcher/process.py
+++ b/launcher/process.py
@@ -1,0 +1,150 @@
+"""Subprocess helpers: run child processes windowless and stream their output."""
+
+import logging
+import os
+import subprocess
+import sys
+
+LOGGER = logging.getLogger(__name__)
+
+CREATE_NO_WINDOW = 0x08000000
+CREATE_NEW_CONSOLE = 0x00000010
+
+# setup.py prompts with input() when several environments exist. We hand every
+# child a stdin full of newlines so those prompts resolve to their default
+# instead of raising EOFError.
+_AUTO_ANSWER = "\n" * 32
+
+
+def _creation_flags(visible_console):
+    if os.name != "nt":
+        return 0
+    return CREATE_NEW_CONSOLE if visible_console else CREATE_NO_WINDOW
+
+
+def popen(argv, cwd=None, env=None, visible_console=False, capture=True):
+    kwargs = {
+        "cwd": cwd,
+        "env": env,
+        "creationflags": _creation_flags(visible_console),
+    }
+    if capture:
+        kwargs.update(
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            bufsize=1,
+        )
+    LOGGER.info("Running: %s (cwd=%s)", subprocess.list2cmdline(argv), cwd)
+    return subprocess.Popen(argv, **kwargs)
+
+
+def stream(argv, on_line, cwd=None, env=None, cancelled=None):
+    """Run ``argv``, forwarding every output line to ``on_line``.
+
+    Returns the process exit code, or -1 if ``cancelled()`` asked us to stop.
+    """
+    proc = popen(argv, cwd=cwd, env=env)
+    try:
+        if proc.stdin is not None:
+            try:
+                proc.stdin.write(_AUTO_ANSWER)
+                proc.stdin.flush()
+            except OSError:
+                pass
+    finally:
+        if proc.stdin is not None:
+            try:
+                proc.stdin.close()
+            except OSError:
+                pass
+
+    assert proc.stdout is not None
+    try:
+        for line in proc.stdout:
+            line = line.rstrip("\r\n")
+            if line:
+                on_line(line)
+            if cancelled is not None and cancelled():
+                terminate(proc)
+                return -1
+        proc.wait()
+        return proc.returncode
+    finally:
+        try:
+            proc.stdout.close()
+        except OSError:
+            pass
+
+
+def run_quiet(argv, cwd=None, timeout=30):
+    """Run a short command and return (returncode, combined output)."""
+    try:
+        completed = subprocess.run(
+            argv,
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            creationflags=_creation_flags(False),
+        )
+        return completed.returncode, (completed.stdout or "").strip()
+    except (OSError, subprocess.SubprocessError) as exc:
+        return 1, str(exc)
+
+
+def terminate(proc):
+    """Stop a process and the console child processes it spawned."""
+    if proc is None or proc.poll() is not None:
+        return
+    if os.name == "nt":
+        # setup.py and wgp.py both spawn grandchildren (pip, ffmpeg, workers);
+        # taskkill /T is the only reliable way to take the whole tree down.
+        run_quiet(["taskkill", "/F", "/T", "/PID", str(proc.pid)], timeout=20)
+    else:
+        proc.terminate()
+    try:
+        proc.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+def open_in_explorer(path):
+    if not os.path.exists(path):
+        return
+    if os.name == "nt":
+        os.startfile(path)  # noqa: S606 - documented Windows shell open
+    else:
+        subprocess.Popen(["xdg-open", path])
+
+
+def open_console(argv, cwd=None):
+    """Launch an interactive command in its own visible console window."""
+    return popen(argv, cwd=cwd, visible_console=True, capture=False)
+
+
+def child_env(extra=None):
+    env = os.environ.copy()
+    env.setdefault("PYTHONIOENCODING", "utf-8")
+    env.setdefault("PYTHONUNBUFFERED", "1")
+    # PyInstaller leaks its bootstrap paths into children; strip them so the
+    # WanGP environment's own interpreter resolves its packages normally.
+    for key in ("PYTHONHOME", "PYTHONPATH", "_MEIPASS2"):
+        env.pop(key, None)
+    if extra:
+        env.update(extra)
+    return env
+
+
+def bundled_python():
+    """The interpreter to use for plain-stdlib chores such as setup.py."""
+    if getattr(sys, "frozen", False):
+        return None
+    return sys.executable

--- a/launcher/requirements-launcher.txt
+++ b/launcher/requirements-launcher.txt
@@ -1,0 +1,6 @@
+# Build-time and runtime dependencies of the Windows launcher only.
+# WanGP's own dependencies live in the repository-level requirements.txt.
+pywebview==5.4
+pythonnet==3.0.5
+pyinstaller==6.11.1
+pillow==11.0.0

--- a/launcher/server.py
+++ b/launcher/server.py
@@ -1,0 +1,165 @@
+"""Run wgp.py and know when its web UI is ready to be shown."""
+
+import logging
+import os
+import socket
+import threading
+import time
+
+from . import config, environment, process
+
+LOGGER = logging.getLogger(__name__)
+
+# run.bat restarts WanGP when it exits with this code (the in-app "restart"
+# button); the launcher has to honour the same contract.
+RESTART_EXIT_CODE = 42
+
+
+def _port_is_free(host, port):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind((host, port))
+            return True
+        except OSError:
+            return False
+
+
+def pick_port(host, preferred):
+    if preferred and _port_is_free(host, preferred):
+        return preferred
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((host, 0))
+        chosen = sock.getsockname()[1]
+    LOGGER.info("Port %s unavailable, using %s instead", preferred, chosen)
+    return chosen
+
+
+def _port_accepts_connections(host, port):
+    try:
+        with socket.create_connection((host, port), timeout=1):
+            return True
+    except OSError:
+        return False
+
+
+class WanGPServer:
+    """Owns the wgp.py process: start, watch, restart on code 42, stop."""
+
+    def __init__(self, root, python_exe, cfg, on_line=None):
+        self.root = root
+        self.python_exe = python_exe
+        self.cfg = cfg
+        self.on_line = on_line or (lambda _line: None)
+
+        server_cfg = cfg.get("server", {})
+        self.host = server_cfg.get("host", "127.0.0.1")
+        self.port = pick_port(self.host, server_cfg.get("preferred_port", 7860))
+        self.timeout = server_cfg.get("startup_timeout_seconds", 900)
+
+        self._proc = None
+        self._reader = None
+        self._stopping = threading.Event()
+        self._exited = threading.Event()
+        self._log_path = os.path.join(config.logs_dir(), "wangp-server.log")
+        self._log_handle = None
+        self._restart_callback = None
+
+    @property
+    def url(self):
+        return f"http://{self.host}:{self.port}"
+
+    @property
+    def log_path(self):
+        return self._log_path
+
+    def _argv(self):
+        argv = [
+            self.python_exe,
+            environment.MAIN_SCRIPT,
+            "--server-name",
+            self.host,
+            "--server-port",
+            str(self.port),
+        ]
+        argv.extend(environment.read_extra_args(self.root))
+        return argv
+
+    def _emit(self, line):
+        self.on_line(line)
+        if self._log_handle is not None:
+            try:
+                self._log_handle.write(line + "\n")
+                self._log_handle.flush()
+            except OSError:
+                pass
+
+    def _pump(self):
+        """Forward the child's output, then restart it if it asked for one."""
+        assert self._proc is not None and self._proc.stdout is not None
+        for raw in self._proc.stdout:
+            self._emit(raw.rstrip("\r\n"))
+        self._proc.wait()
+        code = self._proc.returncode
+        LOGGER.info("wgp.py exited with code %s", code)
+
+        if code == RESTART_EXIT_CODE and not self._stopping.is_set():
+            self._emit("[*] WanGP asked for a restart; relaunching ...")
+            try:
+                self._spawn()
+            except OSError as exc:
+                self._emit(f"[!] Restart failed: {exc}")
+                self._exited.set()
+            return
+
+        if not self._stopping.is_set():
+            self._emit(f"[!] WanGP stopped unexpectedly (exit code {code}).")
+        self._exited.set()
+
+    def _spawn(self):
+        if self._log_handle is None:
+            self._log_handle = open(self._log_path, "a", encoding="utf-8", errors="replace")
+        self._proc = process.popen(self._argv(), cwd=self.root, env=process.child_env())
+        self._reader = threading.Thread(target=self._pump, name="wangp-server-output", daemon=True)
+        self._reader.start()
+
+    def start(self):
+        self._emit(f"[*] Starting WanGP on {self.url}")
+        self._spawn()
+
+    def wait_until_ready(self, cancelled=None):
+        """Block until the web UI answers, the process dies, or we time out."""
+        deadline = time.monotonic() + self.timeout
+        announced = False
+        while time.monotonic() < deadline:
+            if cancelled is not None and cancelled():
+                return False
+            if _port_accepts_connections(self.host, self.port):
+                self._emit("[*] Web interface is up.")
+                return True
+            if self._exited.is_set():
+                return False
+            if not announced and time.monotonic() > deadline - self.timeout + 20:
+                announced = True
+                self._emit("[*] Still starting: WanGP is loading its model list ...")
+            time.sleep(0.5)
+        self._emit(f"[!] WanGP did not answer within {self.timeout} seconds.")
+        return False
+
+    def is_running(self):
+        return self._proc is not None and self._proc.poll() is None
+
+    def stop(self):
+        self._stopping.set()
+        if self._proc is not None:
+            self._emit("[*] Stopping WanGP ...")
+            process.terminate(self._proc)
+            self._proc = None
+        if self._reader is not None and self._reader.is_alive():
+            self._reader.join(timeout=5)
+        self._reader = None
+        if self._log_handle is not None:
+            try:
+                self._log_handle.close()
+            finally:
+                self._log_handle = None

--- a/launcher/tests/__init__.py
+++ b/launcher/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Offline tests for the WanGP Windows launcher."""

--- a/launcher/tests/test_launcher.py
+++ b/launcher/tests/test_launcher.py
@@ -1,0 +1,189 @@
+"""Offline tests for the launcher's platform-independent logic.
+
+These run anywhere: they never import pywebview and never touch a GPU. The
+Windows-only paths (installer flow, WebView2 window) are covered by the
+smoke-test step of the build workflow instead.
+"""
+
+import os
+import sys
+import tempfile
+import textwrap
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from launcher import config, environment, process, server  # noqa: E402
+
+
+class ConfigTests(unittest.TestCase):
+    def test_defaults_are_complete(self):
+        cfg = config.load_config()
+        for key in ("app_name", "app_version", "repo_url", "python", "server", "window"):
+            self.assertIn(key, cfg)
+        self.assertEqual(cfg["python"]["series"], "3.11")
+
+    def test_bundled_json_overrides_defaults(self):
+        cfg = config.load_config()
+        # launcher_config.json ships next to the module and must win.
+        self.assertTrue(cfg["repo_url"].endswith(".git"))
+        self.assertIn("python.org", cfg["python"]["installer_url"])
+
+    def test_install_root_is_the_checkout_from_source(self):
+        root = config.install_root()
+        self.assertTrue(os.path.isfile(os.path.join(root, "wgp.py")))
+        self.assertTrue(os.path.isfile(os.path.join(root, "setup.py")))
+
+    def test_setup_page_is_where_the_ui_looks_for_it(self):
+        self.assertTrue(os.path.isfile(os.path.join(config.bundle_dir(), "web", "setup.html")))
+
+
+class ExtraArgsTests(unittest.TestCase):
+    def _root_with_args(self, contents):
+        root = tempfile.mkdtemp()
+        os.makedirs(os.path.join(root, "scripts"))
+        with open(os.path.join(root, "scripts", "args.txt"), "w", encoding="utf-8") as handle:
+            handle.write(contents)
+        return root
+
+    def test_missing_file_yields_no_args(self):
+        self.assertEqual(environment.read_extra_args(tempfile.mkdtemp()), [])
+
+    def test_flags_are_split_and_comments_ignored(self):
+        root = self._root_with_args("# comment\n--advanced --profile 3\n\n--fp16\n")
+        self.assertEqual(environment.read_extra_args(root), ["--advanced", "--profile", "3", "--fp16"])
+
+    def test_browser_and_server_flags_are_stripped(self):
+        root = self._root_with_args("--advanced --open-browser --server-port 9000 --share --listen --fp16\n")
+        self.assertEqual(environment.read_extra_args(root), ["--advanced", "--fp16"])
+
+    def test_equals_form_of_server_options_is_stripped(self):
+        root = self._root_with_args("--server-name=0.0.0.0 --steps 20\n")
+        self.assertEqual(environment.read_extra_args(root), ["--steps", "20"])
+
+
+class EnvPythonTests(unittest.TestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+
+    def _make(self, *parts):
+        path = os.path.join(self.root, *parts)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        open(path, "w").close()
+        return path
+
+    def test_venv_uses_the_scripts_layout(self):
+        expected = self._make("env_venv", "Scripts", "python.exe")
+        self.assertEqual(environment.env_python(self.root, "venv", "./env_venv", "sys"), expected)
+
+    def test_conda_interpreter_sits_at_the_env_root(self):
+        expected = self._make("env_conda", "python.exe")
+        self.assertEqual(environment.env_python(self.root, "conda", "./env_conda", "sys"), expected)
+
+    def test_env_type_none_falls_back_to_the_system_interpreter(self):
+        self.assertEqual(environment.env_python(self.root, "none", "", "/usr/bin/python3"), "/usr/bin/python3")
+
+    def test_missing_interpreter_is_an_actionable_error(self):
+        with self.assertRaises(environment.EnvironmentError_) as caught:
+            environment.env_python(self.root, "venv", "./gone", "sys")
+        self.assertIn("Repair", str(caught.exception))
+
+
+class SetupBridgeTests(unittest.TestCase):
+    """get_env_info must parse exactly what setup.py prints, as run.bat does."""
+
+    def _fake_checkout(self, setup_body):
+        root = tempfile.mkdtemp()
+        with open(os.path.join(root, "setup.py"), "w", encoding="utf-8") as handle:
+            handle.write(textwrap.dedent(setup_body))
+        open(os.path.join(root, "wgp.py"), "w").close()
+        return root
+
+    def test_parses_the_env_info_line(self):
+        root = self._fake_checkout(
+            """
+            import sys
+            print("[*] chatter that must be ignored")
+            print("ENV_INFO|venv|./env_venv")
+            sys.exit(0)
+            """
+        )
+        self.assertEqual(environment.get_env_info(root, sys.executable), ("venv", "./env_venv"))
+
+    def test_non_zero_exit_means_no_environment(self):
+        root = self._fake_checkout(
+            """
+            import sys
+            sys.exit(1)
+            """
+        )
+        self.assertIsNone(environment.get_env_info(root, sys.executable))
+
+    def test_is_wangp_checkout_requires_both_scripts(self):
+        root = self._fake_checkout("pass")
+        self.assertTrue(environment.is_wangp_checkout(root))
+        os.remove(os.path.join(root, "wgp.py"))
+        self.assertFalse(environment.is_wangp_checkout(root))
+
+
+class ProcessTests(unittest.TestCase):
+    def test_stream_forwards_every_line_and_returns_the_exit_code(self):
+        script = "import sys; [print('line %d' % i) for i in range(3)]; sys.exit(7)"
+        lines = []
+        code = process.stream([sys.executable, "-c", script], on_line=lines.append)
+        self.assertEqual(code, 7)
+        self.assertEqual(lines, ["line 0", "line 1", "line 2"])
+
+    def test_children_receive_newlines_so_input_prompts_do_not_crash(self):
+        # setup.py calls input() when several environments exist; without the
+        # pre-fed stdin that would raise EOFError and abort the update.
+        script = "answer = input('pick: '); print('got[%s]' % answer.strip())"
+        lines = []
+        code = process.stream([sys.executable, "-c", script], on_line=lines.append)
+        self.assertEqual(code, 0)
+        self.assertIn("got[]", "".join(lines))
+
+    def test_cancellation_stops_the_stream(self):
+        script = "import sys, time\nfor i in range(1000):\n    print(i); sys.stdout.flush(); time.sleep(0.01)"
+        lines = []
+        code = process.stream(
+            [sys.executable, "-u", "-c", script],
+            on_line=lines.append,
+            cancelled=lambda: len(lines) >= 3,
+        )
+        self.assertEqual(code, -1)
+        self.assertLess(len(lines), 50)
+
+    def test_run_quiet_captures_output(self):
+        code, out = process.run_quiet([sys.executable, "-c", "print('hello')"])
+        self.assertEqual(code, 0)
+        self.assertEqual(out, "hello")
+
+    def test_child_env_drops_pyinstaller_leakage(self):
+        os.environ["PYTHONHOME"] = "/should/not/leak"
+        try:
+            env = process.child_env()
+            self.assertNotIn("PYTHONHOME", env)
+            self.assertEqual(env["PYTHONIOENCODING"], "utf-8")
+        finally:
+            os.environ.pop("PYTHONHOME", None)
+
+
+class PortTests(unittest.TestCase):
+    def test_preferred_port_is_used_when_free(self):
+        free = server.pick_port("127.0.0.1", 0)
+        self.assertGreater(free, 0)
+
+    def test_busy_preferred_port_falls_back(self):
+        import socket
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as taken:
+            taken.bind(("127.0.0.1", 0))
+            taken.listen(1)
+            busy = taken.getsockname()[1]
+            chosen = server.pick_port("127.0.0.1", busy)
+            self.assertNotEqual(chosen, busy)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/launcher/ui.py
+++ b/launcher/ui.py
@@ -1,0 +1,417 @@
+"""The launcher window: a setup/progress page that becomes the WanGP web UI."""
+
+import logging
+import os
+import threading
+import webbrowser
+
+import webview
+
+from . import config, environment, prereqs, process, server
+
+LOGGER = logging.getLogger(__name__)
+
+MAX_CONSOLE_LINES = 500
+
+
+def _load_page():
+    path = os.path.join(config.bundle_dir(), "web", "setup.html")
+    with open(path, "r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+class LauncherApi:
+    """Bridge exposed to the setup page as ``window.pywebview.api``."""
+
+    def __init__(self, app):
+        self._app = app
+
+    def get_state(self):
+        return self._app.snapshot()
+
+    def retry(self):
+        self._app.retry()
+        return True
+
+    def open_logs(self):
+        process.open_in_explorer(config.logs_dir())
+        return True
+
+    def quit(self):
+        self._app.shutdown()
+        return True
+
+
+class LauncherApp:
+    """Bootstraps prerequisites, the environment and the server, then shows it."""
+
+    def __init__(self, cfg):
+        self.cfg = cfg
+        self.root = config.install_root()
+        self.window = None
+        self.server = None
+
+        self._lock = threading.Lock()
+        self._lines = []
+        self._title = "Starting…"
+        self._detail = ""
+        self._error = ""
+        self._done = False
+        self._can_retry = False
+        self._busy = threading.Event()
+        self._shutting_down = threading.Event()
+        self._system_python = None
+        self._runtime_python = None
+        self._git_exe = None
+
+    # ----------------------------------------------------------------- state
+
+    def snapshot(self):
+        with self._lock:
+            return {
+                "version": self.cfg.get("app_version", ""),
+                "title": self._title,
+                "detail": self._detail,
+                "lines": list(self._lines),
+                "error": self._error,
+                "done": self._done,
+                "can_retry": self._can_retry,
+            }
+
+    def log(self, line):
+        LOGGER.info("%s", line)
+        with self._lock:
+            self._lines.append(line)
+            if len(self._lines) > MAX_CONSOLE_LINES:
+                del self._lines[: len(self._lines) - MAX_CONSOLE_LINES]
+
+    def phase(self, title, detail=""):
+        with self._lock:
+            self._title = title
+            self._detail = detail
+            self._error = ""
+            self._done = False
+            self._can_retry = False
+
+    def fail(self, message):
+        LOGGER.error("%s", message)
+        with self._lock:
+            self._error = message
+            self._title = "Something went wrong"
+            self._detail = "Fix the problem above, then retry."
+            self._can_retry = True
+            self._done = False
+
+    def finish(self, title, detail=""):
+        with self._lock:
+            self._title = title
+            self._detail = detail
+            self._done = True
+            self._can_retry = False
+
+    # ------------------------------------------------------------- lifecycle
+
+    def show_setup_page(self):
+        if self.window is not None:
+            self.window.load_html(_load_page())
+
+    def boot(self, window):
+        self.window = window
+        self._run_guarded(self._bootstrap)
+
+    def retry(self):
+        if self._busy.is_set():
+            return
+        self._run_guarded(self._bootstrap)
+
+    def _run_guarded(self, target):
+        def wrapper():
+            self._busy.set()
+            try:
+                target()
+            except Exception as exc:  # surfaced in the page, detailed in the log
+                LOGGER.exception("Launcher step failed")
+                self.fail(str(exc))
+            finally:
+                self._busy.clear()
+
+        threading.Thread(target=wrapper, name="wangp-launcher", daemon=True).start()
+
+    def _bootstrap(self):
+        with self._lock:
+            self._lines = []
+        self.phase("Checking the installation…")
+
+        if not environment.is_wangp_checkout(self.root):
+            raise environment.EnvironmentError_(
+                f"No WanGP installation found in:\n  {self.root}\n\n"
+                "wgp.py and setup.py should sit next to the launcher. Reinstall WanGP."
+            )
+        self.log(f"[*] Installation folder: {self.root}")
+
+        self._ensure_python()
+        self._ensure_git()
+        self._ensure_environment()
+        self._start_server()
+
+    def _ensure_python(self):
+        series = self.cfg["python"].get("series", "3.11")
+        self.phase(f"Looking for Python {series}…")
+        found = prereqs.find_python(series)
+        if found:
+            self.log(f"[*] Python {series} found: {found}")
+            self._system_python = found
+            return
+
+        stray = prereqs.python_present_but_unlaunchable(series)
+        if stray:
+            self.log(f"[!] Found {stray} but the 'py' launcher does not know about it.")
+        self.phase(
+            f"Installing Python {series}…",
+            "Required to build the WanGP environment. Nothing else on your system is changed.",
+        )
+        self._system_python = prereqs.install_python(self.cfg, on_line=self.log)
+
+    def _ensure_git(self):
+        self.phase("Looking for Git…")
+        self._git_exe = prereqs.find_git()
+        if self._git_exe:
+            self.log(f"[*] Git found: {self._git_exe}")
+            return
+        if not self.cfg.get("git", {}).get("portable_url"):
+            self.log("[!] Git is missing. WanGP will run, but updates will be unavailable.")
+            return
+        try:
+            self.phase("Installing a private copy of Git…", "Used only to update WanGP later.")
+            self._git_exe = prereqs.install_portable_git(self.cfg, on_line=self.log)
+        except prereqs.PrereqError as exc:
+            # Git is only needed for updates, so this must never block a launch.
+            self.log(f"[!] Could not install Git: {exc}")
+            self.log("[!] WanGP will still run; install Git manually to enable updates.")
+
+    def _env(self):
+        return prereqs.env_with_git(self._git_exe)
+
+    def _ensure_environment(self):
+        self.phase("Checking the Python environment…")
+        runtime = None
+        if environment.has_environment(self.root):
+            try:
+                runtime = environment.resolve_runtime_python(self.root, self._system_python)
+            except environment.EnvironmentError_ as exc:
+                self.log(f"[!] {exc}")
+
+        if runtime is None:
+            self.phase(
+                "First-time setup",
+                "Detecting your GPU and installing PyTorch and the acceleration kernels. "
+                "This takes a while and needs several GB of disk space.",
+            )
+            environment.install_auto(
+                self.root,
+                self._system_python,
+                self.cfg.get("env_type", "venv"),
+                on_line=self.log,
+                env=self._env(),
+                cancelled=self._shutting_down.is_set,
+            )
+            runtime = environment.resolve_runtime_python(self.root, self._system_python)
+            if runtime is None:
+                raise environment.EnvironmentError_(
+                    "Setup finished but no active environment was registered.\n"
+                    "Open 'Manage environments…' to select one."
+                )
+            config.write_state(installed=True)
+
+        self.log(f"[*] Using interpreter: {runtime}")
+        self._runtime_python = runtime
+
+    def _start_server(self):
+        self.phase("Starting WanGP…", "Loading the model list; the interface opens by itself.")
+        self.server = server.WanGPServer(self.root, self._runtime_python, self.cfg, on_line=self.log)
+        self.server.start()
+        if not self.server.wait_until_ready(cancelled=self._shutting_down.is_set):
+            if self._shutting_down.is_set():
+                return
+            raise environment.EnvironmentError_(
+                "WanGP started but its web interface never answered.\n"
+                "The last lines above usually say why."
+            )
+        self.finish("WanGP is ready", "Opening the interface…")
+        self.window.load_url(self.server.url)
+
+    # ----------------------------------------------------------- menu actions
+
+    def _requires_python(self):
+        """Maintenance needs the interpreter the bootstrap resolved."""
+        if self._system_python:
+            return True
+        self.show_setup_page()
+        self.fail(
+            "WanGP has not finished its first-time setup yet, so maintenance is "
+            "unavailable.\nUse Retry to finish the setup first."
+        )
+        return False
+
+    def _with_stopped_server(self, title, detail, action):
+        """Run maintenance with the server down, then bring it back up."""
+        if self._busy.is_set() or not self._requires_python():
+            return
+
+        def task():
+            self.show_setup_page()
+            self.phase(title, detail)
+            with self._lock:
+                self._lines = []
+            if self.server is not None:
+                self.server.stop()
+                self.server = None
+            action()
+            self._start_server()
+
+        self._run_guarded(task)
+
+    def action_update(self):
+        def run():
+            environment.bootstrap_git_repo(
+                self.root,
+                self._git_exe,
+                self.cfg.get("repo_url", ""),
+                self.cfg.get("repo_branch", "main"),
+                on_line=self.log,
+                env=self._env(),
+            )
+            environment.update(self.root, self._system_python, on_line=self.log, env=self._env())
+
+        self._with_stopped_server(
+            "Updating WanGP…",
+            "Pulling the latest code and refreshing requirements.",
+            run,
+        )
+
+    def action_repair(self):
+        def run():
+            environment.install_auto(
+                self.root,
+                self._system_python,
+                self.cfg.get("env_type", "venv"),
+                on_line=self.log,
+                env=self._env(),
+                cancelled=self._shutting_down.is_set,
+            )
+            self._runtime_python = environment.resolve_runtime_python(self.root, self._system_python)
+            if self._runtime_python is None:
+                raise environment.EnvironmentError_("The rebuilt environment could not be resolved.")
+
+        self._with_stopped_server(
+            "Rebuilding the environment…",
+            "The existing environment is replaced. Models, LoRAs and outputs are untouched.",
+            run,
+        )
+
+    def action_restart_server(self):
+        def run():
+            self.log("[*] Restarting WanGP …")
+
+        self._with_stopped_server("Restarting WanGP…", "", run)
+
+    def action_manage_envs(self):
+        if self._requires_python():
+            environment.open_manage_console(self.root, self._system_python, env=self._env())
+
+    def action_upgrade_components(self):
+        if self._requires_python():
+            environment.open_upgrade_console(self.root, self._system_python, env=self._env())
+
+    def action_open_install_folder(self):
+        process.open_in_explorer(self.root)
+
+    def action_open_outputs(self):
+        outputs = os.path.join(self.root, "outputs")
+        process.open_in_explorer(outputs if os.path.isdir(outputs) else self.root)
+
+    def action_open_logs(self):
+        process.open_in_explorer(config.logs_dir())
+
+    def action_open_in_browser(self):
+        if self.server is not None and self.server.is_running():
+            webbrowser.open(self.server.url)
+
+    def shutdown(self):
+        self._shutting_down.set()
+        if self.server is not None:
+            self.server.stop()
+            self.server = None
+        if self.window is not None:
+            try:
+                self.window.destroy()
+            except Exception:  # the window may already be gone
+                LOGGER.debug("Window already destroyed", exc_info=True)
+
+
+def _build_menu(app):
+    """Native menu bar. Older pywebview builds lack this API, so it is optional."""
+    try:
+        from webview.menu import Menu, MenuAction, MenuSeparator
+    except ImportError:
+        LOGGER.info("This pywebview build has no menu support; running without a menu bar.")
+        return None
+
+    return [
+        Menu(
+            "WanGP",
+            [
+                MenuAction("Restart WanGP", app.action_restart_server),
+                MenuAction("Open in web browser", app.action_open_in_browser),
+                MenuSeparator(),
+                MenuAction("Quit", app.shutdown),
+            ],
+        ),
+        Menu(
+            "Maintenance",
+            [
+                MenuAction("Update WanGP…", app.action_update),
+                MenuAction("Repair / reinstall environment…", app.action_repair),
+                MenuSeparator(),
+                MenuAction("Manage environments…", app.action_manage_envs),
+                MenuAction("Upgrade Torch / Triton / Sage…", app.action_upgrade_components),
+            ],
+        ),
+        Menu(
+            "Folders",
+            [
+                MenuAction("Installation folder", app.action_open_install_folder),
+                MenuAction("Outputs", app.action_open_outputs),
+                MenuAction("Logs", app.action_open_logs),
+            ],
+        ),
+    ]
+
+
+def run(cfg):
+    app = LauncherApp(cfg)
+    window_cfg = cfg.get("window", {})
+    window = webview.create_window(
+        cfg.get("app_name", "WanGP"),
+        html=_load_page(),
+        js_api=LauncherApi(app),
+        width=window_cfg.get("width", 1450),
+        height=window_cfg.get("height", 940),
+        min_size=(window_cfg.get("min_width", 900), window_cfg.get("min_height", 620)),
+        text_select=True,
+    )
+    window.events.closed += app.shutdown
+
+    start_kwargs = {"gui": "edgechromium", "private_mode": False, "storage_path": config.data_dir()}
+    menu = _build_menu(app)
+    if menu:
+        start_kwargs["menu"] = menu
+
+    try:
+        webview.start(app.boot, window, **start_kwargs)
+    except TypeError:
+        # Fall back for pywebview builds that reject one of the newer options.
+        LOGGER.warning("Retrying webview.start with reduced options", exc_info=True)
+        webview.start(app.boot, window, gui="edgechromium")
+    finally:
+        app.shutdown()

--- a/launcher/wangp.spec
+++ b/launcher/wangp.spec
@@ -1,0 +1,71 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller spec for the WanGP Windows launcher.
+
+Built as a one-folder bundle placed in ``launcher-bin`` inside the WanGP
+installation directory. One-folder starts faster than one-file and avoids the
+temp-extraction pattern that antivirus products tend to flag.
+"""
+
+import os
+
+from PyInstaller.utils.hooks import collect_all
+
+SPEC_DIR = os.path.dirname(os.path.abspath(SPEC))
+REPO_ROOT = os.path.dirname(SPEC_DIR)
+ICON = os.path.join(SPEC_DIR, "assets", "wangp.ico")
+
+# pywebview ships the WebView2 interop assemblies as package data; without
+# collect_all the frozen build starts and then fails to create a window.
+webview_datas, webview_binaries, webview_hidden = collect_all("webview")
+
+a = Analysis(
+    [os.path.join(SPEC_DIR, "main.py")],
+    pathex=[REPO_ROOT],
+    binaries=webview_binaries,
+    datas=webview_datas
+    + [
+        (os.path.join(SPEC_DIR, "web"), "web"),
+        (os.path.join(SPEC_DIR, "launcher_config.json"), "."),
+    ],
+    hiddenimports=webview_hidden
+    + [
+        "webview.platforms.edgechromium",
+        "clr_loader",
+        "pythonnet",
+    ],
+    hookspath=[],
+    runtime_hooks=[],
+    # WanGP's own heavy stack is never imported by the launcher: it runs in the
+    # separate environment setup.py builds.
+    excludes=["torch", "gradio", "numpy", "PIL", "tkinter", "matplotlib", "scipy"],
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="WanGP",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=False,
+    disable_windowed_traceback=False,
+    icon=ICON if os.path.isfile(ICON) else None,
+    version=os.path.join(SPEC_DIR, "assets", "version_info.txt")
+    if os.path.isfile(os.path.join(SPEC_DIR, "assets", "version_info.txt"))
+    else None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=False,
+    name="launcher-bin",
+)

--- a/launcher/web/setup.html
+++ b/launcher/web/setup.html
@@ -1,0 +1,169 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>WanGP</title>
+<style>
+  :root {
+    color-scheme: dark;
+    --bg: #0f1115;
+    --panel: #161a21;
+    --border: #262c37;
+    --text: #e6e9ef;
+    --muted: #8b93a3;
+    --accent: #6ea8fe;
+    --danger: #ff7b72;
+    --ok: #7ee787;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; margin: 0; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font: 14px/1.5 "Segoe UI", system-ui, -apple-system, sans-serif;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 32px;
+  }
+  .card {
+    width: min(860px, 100%);
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 28px 30px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    max-height: 100%;
+  }
+  header { display: flex; align-items: baseline; gap: 12px; }
+  h1 { font-size: 20px; margin: 0; letter-spacing: .2px; }
+  .version { color: var(--muted); font-size: 12px; }
+  .phase { display: flex; align-items: center; gap: 10px; font-size: 15px; font-weight: 600; }
+  .detail { color: var(--muted); margin-top: -10px; }
+  .spinner {
+    width: 15px; height: 15px; flex: none;
+    border: 2px solid var(--border);
+    border-top-color: var(--accent);
+    border-radius: 50%;
+    animation: spin .8s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .spinner.done { animation: none; border: 2px solid var(--ok); }
+  .spinner.failed { animation: none; border: 2px solid var(--danger); }
+  .bar { height: 4px; background: var(--border); border-radius: 999px; overflow: hidden; }
+  .bar > i {
+    display: block; height: 100%; width: 35%; border-radius: 999px;
+    background: linear-gradient(90deg, transparent, var(--accent), transparent);
+    animation: slide 1.6s ease-in-out infinite;
+  }
+  @keyframes slide { 0% { transform: translateX(-100%); } 100% { transform: translateX(320%); } }
+  .bar.stopped > i { animation: none; width: 100%; background: var(--border); }
+  pre {
+    margin: 0; flex: 1; min-height: 220px; overflow: auto;
+    background: #0b0d11; border: 1px solid var(--border); border-radius: 10px;
+    padding: 14px 16px; font: 12px/1.6 "Cascadia Mono", Consolas, monospace;
+    color: #c7cede; white-space: pre-wrap; word-break: break-word;
+  }
+  .error {
+    background: rgba(255, 123, 114, .09);
+    border: 1px solid rgba(255, 123, 114, .35);
+    border-radius: 10px; padding: 12px 14px; color: #ffb3ad; white-space: pre-wrap;
+  }
+  footer { display: flex; gap: 10px; justify-content: flex-end; align-items: center; }
+  button {
+    font: inherit; padding: 8px 16px; border-radius: 8px; cursor: pointer;
+    border: 1px solid var(--border); background: #1d222b; color: var(--text);
+  }
+  button:hover { border-color: var(--accent); }
+  button.primary { background: var(--accent); border-color: var(--accent); color: #0b0d11; font-weight: 600; }
+  button:disabled { opacity: .5; cursor: default; }
+  [hidden] { display: none !important; }
+</style>
+</head>
+<body>
+  <div class="card">
+    <header>
+      <h1>WanGP</h1>
+      <span class="version" id="version"></span>
+    </header>
+
+    <div class="phase"><span class="spinner" id="spinner"></span><span id="title">Starting…</span></div>
+    <div class="detail" id="detail"></div>
+    <div class="bar" id="bar"><i></i></div>
+
+    <div class="error" id="error" hidden></div>
+    <pre id="console"></pre>
+
+    <footer>
+      <button id="logs">Open logs</button>
+      <button id="retry" class="primary" hidden>Retry</button>
+      <button id="quit" hidden>Quit</button>
+    </footer>
+  </div>
+
+<script>
+  const el = (id) => document.getElementById(id);
+  const consoleBox = el("console");
+  let lastCount = 0;
+  let ready = false;
+
+  function api() {
+    return (window.pywebview && window.pywebview.api) ? window.pywebview.api : null;
+  }
+
+  function render(state) {
+    el("version").textContent = state.version ? "v" + state.version : "";
+    el("title").textContent = state.title || "";
+    el("detail").textContent = state.detail || "";
+
+    const lines = state.lines || [];
+    if (lines.length !== lastCount) {
+      // The backend hands us the whole tail buffer; redraw and stick to bottom.
+      const atBottom = consoleBox.scrollHeight - consoleBox.scrollTop - consoleBox.clientHeight < 40;
+      consoleBox.textContent = lines.join("\n");
+      lastCount = lines.length;
+      if (atBottom) consoleBox.scrollTop = consoleBox.scrollHeight;
+    }
+
+    const failed = Boolean(state.error);
+    el("error").hidden = !failed;
+    if (failed) el("error").textContent = state.error;
+
+    el("spinner").className = "spinner" + (failed ? " failed" : (state.done ? " done" : ""));
+    el("bar").className = "bar" + (failed || state.done ? " stopped" : "");
+    el("retry").hidden = !state.can_retry;
+    el("quit").hidden = !failed;
+  }
+
+  async function poll() {
+    const bridge = api();
+    if (bridge) {
+      ready = true;
+      try {
+        render(await bridge.get_state());
+      } catch (err) {
+        /* the window is closing; nothing useful to do */
+      }
+    } else if (!ready) {
+      el("detail").textContent = "Connecting to the launcher…";
+    }
+    setTimeout(poll, 400);
+  }
+
+  el("logs").addEventListener("click", () => api() && api().open_logs());
+  el("retry").addEventListener("click", () => {
+    el("retry").disabled = true;
+    lastCount = -1;
+    api() && api().retry();
+    setTimeout(() => { el("retry").disabled = false; }, 1500);
+  });
+  el("quit").addEventListener("click", () => api() && api().quit());
+
+  window.addEventListener("pywebviewready", poll);
+  poll();
+</script>
+</body>
+</html>


### PR DESCRIPTION
WanGP currently ships as .bat scripts plus a browser tab. This adds a native Windows entry point: a per-user WanGP-Setup.exe and a launcher that hosts the Gradio UI in a WebView2 window.

The launcher deliberately contains no installation logic. setup.py already detects the GPU, picks the CUDA/ROCm profile, builds the environment and installs the acceleration kernels, so the launcher is a graphical facade over its existing CLI (get_env_info, install --auto, update, manage, upgrade) and mirrors run.bat where behaviour is observable: scripts/args.txt is honoured and exit code 42 restarts the app. New GPU profiles added to setup.py need no change here.

First launch installs Python 3.11 when "py -3.11" does not resolve (setup.py builds its venv with it), unpacks a private Git when none is found, then runs the one-click install with live output in the window. Subsequent launches start wgp.py on a free local port and swap the progress page for the interface once the port answers.

Packaging: PyInstaller one-folder bundle in launcher-bin, wrapped by an Inno Setup script that installs per-user without a UAC prompt, keeps the directory page enabled because models need tens of GB, and pulls the WebView2 runtime when Windows lacks it. Uninstall asks before deleting the environment, models and generated media, and defaults to keeping them. A GitHub Actions workflow on windows-latest builds the .exe, since PyInstaller cannot cross-compile from Linux.

The repository ignores dotfiles and *.html wholesale, which hid both the workflow and the launcher's setup page; .gitignore now re-includes them.

Tested: 22 offline unit tests covering the setup.py bridge, args.txt filtering, interpreter resolution, subprocess streaming and cancellation, and port selection. The frozen bundle is verified in CI with a --selftest mode. The WebView2 window, the unattended Python install and the Inno flow are Windows-only and still need a manual pass.


Claude-Session: https://claude.ai/code/session_01Pj7mL2o44XwetNCsnck1ZU