### PR TITLE
Support RTX 20 CUDA 13 setup

### DIFF
--- a/setup_config.json
+++ b/setup_config.json
@@ -40,6 +40,13 @@
                     "linux": "-U \"triton<3.4\""
                 }
             },
+            "v36": {
+                "label": "Triton 3.6.0 (Torch 2.10)",
+                "cmd": {
+                    "win": "-U \"triton-windows==3.6.0.post26\"",
+                    "linux": "-U \"triton==3.6.0\""
+                }
+            },
             "latest": { 
                 "label": "Triton Latest", 
                 "cmd": {
@@ -93,7 +100,7 @@
                 "label": "Flash Attention 2.8.x",
                 "cmd": {
                     "win": "https://github.com/deepbeepmeep/kernels/releases/download/Flash2/flash_attn-2.8.3-cp311-cp311-win_amd64.whl",
-                    "linux": "flash-attn"
+                    "linux": "flash-attn==2.8.3.post1 --no-build-isolation --no-deps"
                 }
             }
         },
@@ -130,7 +137,7 @@
     },
     "gpu_profiles": {
         "GTX_10":      { "python": "3.10", "torch": "cu128", "triton": null,     "sage": null,       "sparge": null, "flash": null, "kernels": [] },
-        "RTX_20":      { "python": "3.11", "torch": "cu130", "triton": "latest", "sage": "v1", "sparge": null, "flash": "v210", "kernels": ["nunchaku_cu13", "gguf"] },
+        "RTX_20":      { "python": "3.11", "torch": "cu130", "triton": "v36", "sage": "v1", "sparge": null, "flash": null, "kernels": ["nunchaku_cu13", "gguf"] },
         "RTX_30":      { "python": "3.11", "torch": "cu130", "triton": "latest", "sage": "v220_cu13", "sparge": "v010_cu13", "flash": "v210", "kernels": ["nunchaku_cu13", "gguf"] },
         "RTX_40":      { "python": "3.11", "torch": "cu130", "triton": "latest", "sage": "v220_cu13", "sparge": "v010_cu13", "flash": "v210", "kernels": ["nunchaku_cu13", "gguf"] },
         "RTX_50":      { "python": "3.11", "torch": "cu130", "triton": "latest", "sage": "v220_cu13", "sparge": "v010_cu13", "flash": "v210", "kernels": ["nunchaku_cu13","light2xv", "gguf"] },


### PR DESCRIPTION
## Summary

Updates the installer profile for RTX 20-series NVIDIA GPUs running the CUDA 13 / Torch 2.10 stack.

## Changes

- Add an explicit Triton 3.6.0 installer option:
  - Windows: `triton-windows==3.6.0.post26`
  - Linux: `triton==3.6.0`
- Set the RTX 20 profile to use Triton 3.6.0 instead of the unpinned `latest` option.
- Disable FlashAttention 2 for RTX 20 GPUs, where it is unsupported.
- Pin the Linux FlashAttention 2 installation command to `flash-attn==2.8.3.post1` and add the required `--no-build-isolation --no-deps` options for supported GPUs.

## Scope

This change affects the RTX 20 profile only. RTX 30, RTX 40, and RTX 50 profiles continue to use their existing Triton configuration.
