### PR TITLE
fix(ltx2): optimize VRAM in NAG text encoding and cross-attention for…

### DIFF
--- a/models/ltx2/ltx_core/model/transformer/attention.py
+++ b/models/ltx2/ltx_core/model/transformer/attention.py
@@ -219,67 +219,100 @@ class Attention(torch.nn.Module):
         q = self.to_q(x)
         context = x if context is None else context
         x = None
+        # Low-VRAM NAG path: when context is doubled (pos+neg concatenated),
+        # project and attend each half SEPARATELY to avoid the full doubled allocation.
+        _nag_cap = 0
+        if cross_attn and NAG is not None:
+            _nag_cap = int(NAG.get("cap_embed_len", 0) or 0)
+        _ctx_seq = context.shape[0] if context.dim() == 2 else context.shape[1]
+        if _nag_cap > 0 and _ctx_seq == _nag_cap * 2:
+            _dim = 0 if context.dim() == 2 else 1
+            ctx_pos = context.narrow(_dim, 0, _nag_cap)
+            ctx_neg = context.narrow(_dim, _nag_cap, _nag_cap)
+            context = None
+
+            # --- Positive half: project, norm, reshape, attend ---
+            k_pos = self.to_k(ctx_pos)
+            v_pos = self.to_v(ctx_pos)
+            ctx_pos = None
+            self.q_norm(q)
+            self.k_norm(k_pos)
+            if pe is not None:
+                apply_rotary_emb_inplace(q, pe, self.rope_type)
+                apply_rotary_emb_inplace(k_pos, pe if k_pe is None else k_pe, self.rope_type)
+            q_4d = q.view(q.shape[0], -1, self.heads, self.dim_head)
+            k_pos = k_pos.view(k_pos.shape[0], -1, self.heads, self.dim_head)
+            v_pos = v_pos.view(v_pos.shape[0], -1, self.heads, self.dim_head)
+            force_attention, attention_version = self._resolve_attention_override()
+            pos_mask = None if mask is None else mask[..., :_nag_cap]
+            qkv_list = [q_4d, k_pos, v_pos]
+            k_pos = v_pos = None
+            x_pos = pay_attention(
+                qkv_list,
+                attention_mask=pos_mask,
+                force_attention=force_attention,
+                version=attention_version,
+            )
+
+            # --- Negative half: project, norm (k only, q already normed), reshape, attend ---
+            k_neg = self.to_k(ctx_neg)
+            v_neg = self.to_v(ctx_neg)
+            ctx_neg = None
+            self.k_norm(k_neg)
+            if pe is not None:
+                apply_rotary_emb_inplace(k_neg, pe if k_pe is None else k_pe, self.rope_type)
+            k_neg = k_neg.view(k_neg.shape[0], -1, self.heads, self.dim_head)
+            v_neg = v_neg.view(v_neg.shape[0], -1, self.heads, self.dim_head)
+            neg_mask = None if mask is None else mask[..., _nag_cap : _nag_cap * 2]
+            qkv_list = [q_4d, k_neg, v_neg]
+            q = q_4d = k_neg = v_neg = None
+            out = pay_attention(
+                qkv_list,
+                attention_mask=neg_mask,
+                force_attention=force_attention,
+                version=attention_version,
+                recycle_q=True,
+            )
+
+            # --- NAG merge (identical to original) ---
+            nag_scale = float(NAG["scale"])
+            nag_alpha = float(NAG["alpha"])
+            nag_tau = float(NAG["tau"])
+            out.mul_(1 - nag_scale)
+            out.add_(x_pos, alpha=nag_scale)
+            norm_positive = torch.sum(torch.abs(x_pos), dim=(2, 3), keepdim=True)
+            norm_guidance = torch.sum(torch.abs(out), dim=(2, 3), keepdim=True)
+            scale = norm_guidance / norm_positive
+            torch.nan_to_num(scale, nan=10.0, posinf=10.0, neginf=10.0, out=scale)
+            factor = (norm_positive * nag_tau) / (norm_guidance + 1e-7)
+            out = torch.where(scale > nag_tau, out * factor, out)
+            del norm_positive, norm_guidance, scale, factor
+            x_pos.mul_(1 - nag_alpha)
+            out.mul_(nag_alpha)
+            out.add_(x_pos)
+            x_pos = None
+            if self.to_gate_logits is not None:
+                gate_logits = self.to_gate_logits(gate_input)
+                gates = 2.0 * torch.sigmoid(gate_logits).to(dtype=out.dtype)
+                out.mul_(gates.unsqueeze(-1))
+            gate_input = None
+            out = out.flatten(2, 3)
+            out = self.to_out(out)
+            return out
+
+        # --- Normal (non-NAG) path ---
         k = self.to_k(context)
         v = self.to_v(context)
         context = None
         self.q_norm(q)
         self.k_norm(k)
-
         if pe is not None:
             apply_rotary_emb_inplace(q, pe, self.rope_type)
             apply_rotary_emb_inplace(k, pe if k_pe is None else k_pe, self.rope_type)
-
         q = q.view(q.shape[0], -1, self.heads, self.dim_head)
         k = k.view(k.shape[0], -1, self.heads, self.dim_head)
         v = v.view(v.shape[0], -1, self.heads, self.dim_head)
         force_attention, attention_version = self._resolve_attention_override()
-
-        if cross_attn and NAG is not None:
-            cap_len = int(NAG.get("cap_embed_len", 0) or 0)
-            if cap_len > 0 and k.shape[1] == cap_len * 2:
-                pos_mask = None if mask is None else mask[..., :cap_len]
-                neg_mask = None if mask is None else mask[..., cap_len : cap_len * 2]
-                qkv_list = [q, k[:, :cap_len], v[:, :cap_len]]
-                # Keep the merge in attention-output space with in-place ops, following the Wan low-allocation path.
-                x_pos = pay_attention(
-                    qkv_list,
-                    attention_mask=pos_mask,
-                    force_attention=force_attention,
-                    version=attention_version,
-                )
-                qkv_list = [q, k[:, cap_len : cap_len * 2], v[:, cap_len : cap_len * 2]]
-                q = k = v = None
-                out = pay_attention(
-                    qkv_list,
-                    attention_mask=neg_mask,
-                    force_attention=force_attention,
-                    version=attention_version,
-                    recycle_q=True,
-                )
-                nag_scale = float(NAG["scale"])
-                nag_alpha = float(NAG["alpha"])
-                nag_tau = float(NAG["tau"])
-                out.mul_(1 - nag_scale)
-                out.add_(x_pos, alpha=nag_scale)
-                norm_positive = torch.sum(torch.abs(x_pos), dim=(2, 3), keepdim=True)
-                norm_guidance = torch.sum(torch.abs(out), dim=(2, 3), keepdim=True)
-                scale = norm_guidance / norm_positive
-                torch.nan_to_num(scale, nan=10.0, posinf=10.0, neginf=10.0, out=scale)
-                factor = (norm_positive * nag_tau) / (norm_guidance + 1e-7)
-                out = torch.where(scale > nag_tau, out * factor, out)
-                del norm_positive, norm_guidance, scale, factor
-                x_pos.mul_(1 - nag_alpha)
-                out.mul_(nag_alpha)
-                out.add_(x_pos)
-                x_pos = None
-                if self.to_gate_logits is not None:
-                    gate_logits = self.to_gate_logits(gate_input)
-                    gates = 2.0 * torch.sigmoid(gate_logits).to(dtype=out.dtype)
-                    out.mul_(gates.unsqueeze(-1))
-                gate_input = None
-                out = out.flatten(2, 3)
-                out = self.to_out(out)
-                return out
 
         qkv_list = [q, k, v]
         q = k = v = None

--- a/models/ltx2/ltx_core/text_encoders/gemma/feature_extractor.py
+++ b/models/ltx2/ltx_core/text_encoders/gemma/feature_extractor.py
@@ -38,10 +38,12 @@ def _norm_and_concat_padded_batch(
 def _norm_and_concat_per_token_rms(encoded_text: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
     b, t, d, l = encoded_text.shape
     variance = torch.mean(encoded_text**2, dim=2, keepdim=True)
-    normed = encoded_text * torch.rsqrt(variance + 1e-6)
-    normed = normed.reshape(b, t, d * l)
+    encoded_text.mul_(torch.rsqrt(variance + 1e-6))
+    del variance
+    normed = encoded_text.reshape(b, t, d * l)
     mask_3d = attention_mask.bool().unsqueeze(-1)
-    return torch.where(mask_3d, normed, torch.zeros_like(normed))
+    normed.masked_fill_(~mask_3d, 0.0)
+    return normed
 
 
 def _rescale_norm(x: torch.Tensor, target_dim: int, source_dim: int) -> torch.Tensor:
@@ -77,12 +79,15 @@ class GemmaFeaturesExtractorProjLinear(torch.nn.Module, ModelConfigurator["Gemma
         encoded = torch.stack(hidden_states, dim=-1) if isinstance(hidden_states, (list, tuple)) else hidden_states
         if self.is_v2:
             normed = _norm_and_concat_per_token_rms(encoded, attention_mask).to(encoded.dtype)
+            del encoded
             v_dim = self.video_aggregate_embed.out_features
             video = self.video_aggregate_embed(_rescale_norm(normed, v_dim, self.embedding_dim))
             audio = None
             if self.audio_aggregate_embed is not None:
                 a_dim = self.audio_aggregate_embed.out_features
                 audio = self.audio_aggregate_embed(_rescale_norm(normed, a_dim, self.embedding_dim))
+            del normed
+            torch.cuda.empty_cache()
             return video, audio
 
         if self.aggregate_embed is None:

--- a/models/ltx2/ltx_pipelines/distilled.py
+++ b/models/ltx2/ltx_pipelines/distilled.py
@@ -547,12 +547,20 @@ class DistilledPipeline:
                 else:
                     contexts = [(video_context, audio_context)]
             elif float(NAG_scale) > 1.0:
-                contexts = self.text_encoder_cache.encode(
+                context_pos = self.text_encoder_cache.encode(
                     encode_fn,
-                    [prompt, negative_prompt],
+                    [prompt],
                     device=self.device,
                     parallel=True,
-                )
+                )[0]
+                cleanup_memory()
+                context_neg = self.text_encoder_cache.encode(
+                    encode_fn,
+                    [negative_prompt],
+                    device=self.device,
+                    parallel=True,
+                )[0]
+                contexts = [context_pos, context_neg]
                 video_context_mask_builder = None
                 audio_context_mask_builder = None
             else:

--- a/wgp.py
+++ b/wgp.py
@@ -1,6 +1,8 @@
 ############# WanGP Copyright DeepBeepMeep 2025-2026 #############
 import os, sys
 os.environ["GRADIO_LANG"] = "en"
+if "PYTORCH_CUDA_ALLOC_CONF" not in os.environ:
+    os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 p = os.path.dirname(os.path.abspath(__file__))
 if p not in sys.path:
     sys.path.insert(0, p)


### PR DESCRIPTION
### Summary
When Negative Attention Guidance (NAG with Scale > 1.0) is enabled in LTX-2.3, low-VRAM GPUs (<= 6GB) consistently hit `torch.OutOfMemoryError` at two distinct bottlenecks:
1. During text encoding: Gemma encodes `[prompt, negative_prompt]` together as a batch of 2, doubling peak activation memory.
2. During cross-attention: The concatenated doubled context is projected through `to_k()` and `to_v()` in a single allocation (~542 MB), causing CUDA OOM on 4GB-6GB cards.

### Changes Made
1. **Sequential Text Encoding** (`models/ltx2/ltx_pipelines/distilled.py`):
   - Encodes positive prompt first, calls `cleanup_memory()`, then encodes negative prompt sequentially instead of batching them together.
2. **In-Place RMS Normalization** (`models/ltx2/ltx_core/text_encoders/gemma/feature_extractor.py`):
   - Replaced redundant `torch.zeros_like` allocations with in-place `.mul_()` and `.masked_fill_()`.
   - Added explicit `del` and `torch.cuda.empty_cache()` after embedding projection to prevent ~1.1GB memory spikes.
3. **Sequential NAG Cross-Attention** (`models/ltx2/ltx_core/model/transformer/attention.py`):
   - When context length is doubled (`_nag_cap * 2`), splits context into positive/negative halves using zero-copy `.narrow()`.
   - Projects and computes attention on the positive half first, frees tensors, then processes the negative half, and applies the NAG scaling formula.
   - Halves peak attention projection memory (~271 MB vs 542 MB) with zero mathematical difference in output.
4. **CUDA Allocator Setting** (`wgp.py`):
   - Sets `PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True"` by default to avoid VRAM fragmentation.

### Verification
- Tested with `ltx-2.3-22b-distilled-Q4_K_M_light.gguf` on a 4GB VRAM GPU.
- With NAG Scale = 2.0, Stage 1 completes all 8 steps without OOM (previously crashed at step 0 during text encoding or attention layer 1).