### PR TITLE
Linux: attention backend build fixes (SageAttention 2 + SpargeAttn)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ loras_i2v/
 tmp/
 deepy_sessions/
 dlss5/
+SpargeAttn-build/
 /settings/
 
 wgp_config.json

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -109,9 +109,28 @@ pip install https://github.com/woct0rdho/SpargeAttn/releases/download/v0.1.0-win
 ```
 
 #### Linux Install Sparge Attention
+CUDA 13 (and recent nvcc builds in general) cannot compile the upstream git checkout directly: the build fails with `error: identifier "__assert_fail" is undefined` in `cuda_fp8.hpp` / `cuda_fp6.hpp` / `cuda_fp4.hpp`. Use the helper script, which clones the repo, adds a `-DNDEBUG` nvcc flag (which disables the `assert()` calls CUDA 13's headers make inside host/device functions) and installs it. As with the flash attention build, run it with WanGP's environment activated, since it compiles against that environment's PyTorch:
+```
+scripts/install-spargeattn.sh
+```
+
+Manual equivalent:
 ```
 python -m pip install ninja wheel packaging
-python -m pip install --no-build-isolation git+https://github.com/woct0rdho/SpargeAttn.git
+git clone https://github.com/woct0rdho/SpargeAttn
+cd SpargeAttn
+# patch setup.py in two places:
+#   1. add "-DNDEBUG", as a new line right after "-std=c++17", inside NVCC_FLAGS_COMMON
+#   2. in run_instantiations(), replace os.system(f"python {py_file}") with
+#      subprocess.check_call([sys.executable, str(py_file)])   (and add "import sys" at the top)
+python -m pip install --no-build-isolation .
+```
+
+If you only need the kernels for one of your GPUs, limit the build (much faster):
+```
+TORCH_CUDA_ARCH_LIST="12.0" scripts/install-spargeattn.sh   # RTX 50xx only
+TORCH_CUDA_ARCH_LIST="8.9" scripts/install-spargeattn.sh    # RTX 40xx only
+TORCH_CUDA_ARCH_LIST="8.6" scripts/install-spargeattn.sh    # RTX 30xx only
 ```
 
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -88,6 +88,7 @@ pip install sageattention==1.0.6
 
 #### Linux: Install SageAttention 2 for RTX 30XX-50XX
 ```
+# run with WanGP's environment activated
 python -m pip install "setuptools<=75.8.2" --force-reinstall
 git clone https://github.com/thu-ml/SageAttention
 cd SageAttention 

--- a/scripts/install-spargeattn.sh
+++ b/scripts/install-spargeattn.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Installs SpargeAttn (spas_sage_attn) from source.
+#
+# A plain `pip install git+https://github.com/woct0rdho/SpargeAttn.git` fails
+# to build on CUDA 13 with:
+#
+#   /usr/local/cuda/include/cuda_fp8.hpp(...): error: identifier "__assert_fail" is undefined
+#
+# CUDA 13's cuda_fp8.hpp / cuda_fp6.hpp / cuda_fp4.hpp call assert() inside
+# CUDAFORCEINLINE host/device functions. On glibc, assert() expands to a call
+# to __assert_fail(), which nvcc's device frontend does not know about.
+# Adding -DNDEBUG to the nvcc flags disables the assert macro and fixes the
+# build.
+#
+# Additionally, setup.py runs the kernel-instantiation generators with a bare
+# `python` and ignores their exit status. If `python` does not resolve to the
+# build interpreter (e.g. pyenv shims, an unactivated venv), the generated
+# kernels are missing from the wheel and the sm89 module fails to import.
+# This script clones the repo, applies both fixes and installs it.
+#
+# Usage:
+#   scripts/install-spargeattn.sh
+#
+# The build directory is re-cloned on every run (an existing directory is
+# removed first), so the script is safe to re-run even after an interrupted
+# build or an upstream layout change.
+#
+# Optional environment variables:
+#   SPARGEATTN_REPO          git URL (default: https://github.com/woct0rdho/SpargeAttn.git)
+#   SPARGEATTN_BUILD_DIR     where to clone (default: ./SpargeAttn-build)
+#   SPARGEATTN_PYTHON        python interpreter / pip (default: python)
+#   TORCH_CUDA_ARCH_LIST     e.g. "12.0" (RTX 50xx), "8.9" (RTX 40xx) or
+#                        "8.6" (RTX 30xx) to only build for your GPU and
+#                        speed up the build
+set -euo pipefail
+
+REPO="${SPARGEATTN_REPO:-https://github.com/woct0rdho/SpargeAttn.git}"
+BUILD_DIR="${SPARGEATTN_BUILD_DIR:-$(pwd)/SpargeAttn-build}"
+PYTHON="${SPARGEATTN_PYTHON:-python}"
+
+"$PYTHON" -m pip install ninja wheel packaging
+
+# Fresh clone every time: a leftover (possibly patched or half-built)
+# directory would make `git clone` fail, and stale sources could mask
+# upstream layout changes the patches below rely on.
+rm -rf "$BUILD_DIR"
+git clone --depth 1 "$REPO" "$BUILD_DIR"
+
+# Patch setup.py:
+#   1. add -DNDEBUG to NVCC_FLAGS_COMMON so the CUDA 13 __assert_fail build
+#      failure does not occur,
+#   2. run the autogen scripts with the interpreter that is building the
+#      package (a bare `python` may not resolve) and fail loudly on errors.
+"$PYTHON" - "$BUILD_DIR/setup.py" <<'EOF'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+source = path.read_text(encoding="utf-8")
+changed = False
+
+if '"-DNDEBUG"' not in source:
+    if 'NVCC_FLAGS_COMMON' in source:
+        source = source.replace(
+            '    "-std=c++17",\n',
+            '    "-std=c++17",\n    "-DNDEBUG",\n',
+            1,
+        )
+        changed = True
+        print("patched: added -DNDEBUG to NVCC_FLAGS_COMMON")
+    else:
+        print("warning: NVCC_FLAGS_COMMON not found, skipped NDEBUG patch", file=sys.stderr)
+
+if 'os.system(f"python {py_file}")' in source:
+    source = source.replace(
+        'os.system(f"python {py_file}")',
+        'subprocess.check_call([sys.executable, str(py_file)])',
+    )
+    if 'import sys' not in source:
+        source = source.replace('import os\n', 'import os\nimport sys\n', 1)
+    changed = True
+    print("patched: autogen runs with sys.executable and fails loudly")
+
+if changed:
+    path.write_text(source, encoding="utf-8")
+EOF
+
+"$PYTHON" -m pip install --no-build-isolation "$BUILD_DIR"


### PR DESCRIPTION
Two related Linux build fixes:
1) One-line note that the SageAttention 2 build must run with WanGP's venv activated (pip build isolation).
2) scripts/install-spargeattn.sh: a plain 'pip install' of the SpargeAttn git checkout fails on CUDA 13 (__assert_fail in cuda_fp8/6/4.hpp), and its kernel autogen runs with a bare 'python' that may not be the build interpreter. The script clones the repo, adds -DNDEBUG, patches the autogen call to use the build interpreter, and installs with --no-build-isolation. INSTALLATION.md documents the script, the manual equivalent, and per-GPU TORCH_CUDA_ARCH_LIST; .gitignore gains the SpargeAttn-build/ dir.