### PR TITLE
Sliding Window: allow window sizes up to 999 frames for all video models

### DIFF
--- a/shared/extra_settings.py
+++ b/shared/extra_settings.py
@@ -345,7 +345,8 @@ def _sliding_window_size_max(model_def: dict[str, Any] | None, context: dict[str
         raw_max = int(raw_max)
     except Exception:
         raw_max = 257
-    return int(_get_context_get_max_frames(context)(raw_max))
+    # global lower bound so any video model can use a Sliding Window of up to 999 frames
+    return max(int(_get_context_get_max_frames(context)(raw_max)), 999)
 
 
 def _sliding_window_size_step(model_def: dict[str, Any] | None, _context: dict[str, Any]) -> int:

--- a/wgp.py
+++ b/wgp.py
@@ -12471,19 +12471,19 @@ def generate_media_tab(update_form = False, state_dict = None, ui_defaults = Non
                         gr.Markdown("<B>A Sliding Window allows you to generate video with a duration not limited by the Model</B>")
                         gr.Markdown("<B>It is automatically turned on if the number of frames to generate is higher than the Window Size</B>")
                         if diffusion_forcing:
-                            sliding_window_size = setting_slider("sliding_window_size", minimum=37, maximum=get_max_frames(257), value=ui_defaults.get("sliding_window_size", 129), step=20, label="  (recommended to keep it at 97)", visible=True, respect_setting_visibility=False)
+                            sliding_window_size = setting_slider("sliding_window_size", minimum=37, maximum=max(get_max_frames(257), 999), value=ui_defaults.get("sliding_window_size", 129), step=20, label="  (recommended to keep it at 97)", visible=True, respect_setting_visibility=False)
                             sliding_window_overlap = setting_slider("sliding_window_overlap", minimum=17, maximum=97, value=ui_defaults.get("sliding_window_overlap", 17), step=20, visible=True, respect_setting_visibility=False)
                             sliding_window_color_correction_strength = setting_slider("sliding_window_color_correction_strength", value=0, visible=False)
                             sliding_window_overlap_noise = setting_slider("sliding_window_overlap_noise", value=ui_defaults.get("sliding_window_overlap_noise", 20), maximum=100, visible=True)
                             sliding_window_discard_last_frames = setting_slider("sliding_window_discard_last_frames", value=ui_defaults.get("sliding_window_discard_last_frames", 0), visible=False)
                         elif ltxv:
-                            sliding_window_size = setting_slider("sliding_window_size", minimum=41, maximum=get_max_frames(257), value=ui_defaults.get("sliding_window_size", 129), step=8, visible=True, respect_setting_visibility=False)
+                            sliding_window_size = setting_slider("sliding_window_size", minimum=41, maximum=max(get_max_frames(257), 999), value=ui_defaults.get("sliding_window_size", 129), step=8, visible=True, respect_setting_visibility=False)
                             sliding_window_overlap = setting_slider("sliding_window_overlap", minimum=1, maximum=97, value=ui_defaults.get("sliding_window_overlap", 9), step=8, visible=True, respect_setting_visibility=False)
                             sliding_window_color_correction_strength = setting_slider("sliding_window_color_correction_strength", value=0, visible=False)
                             sliding_window_overlap_noise = setting_slider("sliding_window_overlap_noise", value=ui_defaults.get("sliding_window_overlap_noise", 20), maximum=100, visible=False)
                             sliding_window_discard_last_frames = setting_slider("sliding_window_discard_last_frames", value=ui_defaults.get("sliding_window_discard_last_frames", 0), step=8, visible=True)
                         elif hunyuan_video_custom_edit:
-                            sliding_window_size = setting_slider("sliding_window_size", minimum=5, maximum=get_max_frames(257), value=ui_defaults.get("sliding_window_size", 129), step=4, visible=True, respect_setting_visibility=False)
+                            sliding_window_size = setting_slider("sliding_window_size", minimum=5, maximum=max(get_max_frames(257), 999), value=ui_defaults.get("sliding_window_size", 129), step=4, visible=True, respect_setting_visibility=False)
                             sliding_window_overlap = setting_slider("sliding_window_overlap", minimum=1, maximum=97, value=ui_defaults.get("sliding_window_overlap", 5), step=4, visible=True, respect_setting_visibility=False)
                             sliding_window_color_correction_strength = setting_slider("sliding_window_color_correction_strength", value=0, visible=False)
                             sliding_window_overlap_noise = setting_slider("sliding_window_overlap_noise", value=ui_defaults.get("sliding_window_overlap_noise", 20), visible=False)


### PR DESCRIPTION
## What

Raises the **maximum value of the Sliding Window Size slider to at least 999 frames for all video models**, so long videos (e.g. a 30-second generation, which exceeds most models' native frame limit and is therefore generated window by window) can be done with fewer, larger windows.

Two places define the slider's maximum:

- `shared/extra_settings.py` → `_sliding_window_size_max()`: the Advanced-Mode setting. The model-specific max (257-frame fallback) is kept as a *minimum* floor: `max(model_max, 999)`.
- `wgp.py` → the three inline "Sliding Window" sliders (diffusion forcing, LTX Video, Hunyuan Video custom edit), same `max(get_max_frames(257), 999)` treatment.

## Behavior

- **Defaults are unchanged** (e.g. 129 frames): nothing happens unless the user raises the slider, and the slider now simply allows up to 999 frames instead of being capped by the model's native maximum.
- Larger windows mean fewer window switches per generation (less overlap handling / color correction between windows) at the cost of more VRAM per window — the existing per-model minimums and step sizes are untouched.

## Files

- `shared/extra_settings.py` (+2/−1)
- `wgp.py` (+3/−3, three slider call sites)
