### PR TITLE
LTX2: optional Sol-Attn sparse self-attention (experimental)

### DIFF
--- a/models/ltx2/infos.py
+++ b/models/ltx2/infos.py
@@ -120,6 +120,12 @@ Result: the reference voice workflow uses your ID-LoRA file and weight.
 ```
 """
 
+LTX2_SOL_INFOS = """
+## Sol-Attn Sparse Attention
+
+In **Advanced Mode > Misc. > Override Attention Mode**, select **sol** to route the large self-attention blocks of the LTX2 video stream (sequences of 8192 tokens or more with 128-dim heads) through the bundled Triton Sol-Attn kernels. The **Start Tau** slider then appears below the attention selector and shows that End Tau is fixed at `0.8`: the value is used on the first denoising step of each phase and decreases linearly to `0.8` on the final step. The default is `1.3`; use `1.0` for the Sol-Attn paper starting value, increase it to route more attention blocks through the approximate path for greater speed, or lower it for denser attention and higher fidelity. Cross-attention, audio self-attention, masked self-attention, and short sequences always keep the regular attention backend. Sol-Attn requires BF16, Triton 3.6 or newer, and a CUDA NVIDIA GPU using SM86, SM89, SM90, SM100, SM120, or SM121 (such as RTX 30/40/50-series, H100/H200, B100/B200, or DGX Spark); the dropdown reports whether it is available on the current system.
+"""
+
 LTX2_25_INFOS = LTX2_INFOS
 
 LTX2_MSR_INFOS = """

--- a/models/ltx2/ltx2.py
+++ b/models/ltx2/ltx2.py
@@ -9,6 +9,7 @@ from typing import Callable, Iterator
 
 import torch
 import torchaudio
+from mmgp import offload
 from accelerate import init_empty_weights
 from safetensors.torch import load_file
 from shared.utils import files_locator as fl
@@ -27,6 +28,7 @@ from .ltx_core.model.transformer import (
     LTXModelConfigurator,
     X0Model,
 )
+from .ltx_core.model.transformer.sol_attention import SOL_ATTN_TAU_START_KEY
 from .ltx_core.model.upsampler import LatentUpsamplerConfigurator
 from .ltx_core.model.video_vae import VideoDecoderConfigurator, VideoEncoderConfigurator
 from .ltx_core.model.video_vae.diffusion_video_decoder import DiffusionVideoDecoder
@@ -1358,6 +1360,15 @@ class LTX2:
     ):
         if self._interrupt:
             return None
+        # Hand the "Start Tau" (Attention Sparsity) setting to the Sol-Attn policy.
+        attention_sparsity = kwargs.get("attention_sparsity")
+        if attention_sparsity not in (None, ""):
+            try:
+                offload.shared_state[SOL_ATTN_TAU_START_KEY] = float(attention_sparsity)
+            except (TypeError, ValueError):
+                offload.shared_state.pop(SOL_ATTN_TAU_START_KEY, None)
+        else:
+            offload.shared_state.pop(SOL_ATTN_TAU_START_KEY, None)
         joyai_context = None
         joyai_memory_bank = None
         joyai_store_mem_selectors = []

--- a/models/ltx2/ltx2_handler.py
+++ b/models/ltx2/ltx2_handler.py
@@ -8,7 +8,8 @@ from shared.utils.loras_mutipliers import parse_loras_multipliers
 import gradio as gr
 from pathlib import Path
 
-from .infos import LTX2_25_INFOS, LTX2_INFOS, LTX2_MSR_INFOS, LTX2_MSR_V2_INFOS
+from .infos import LTX2_25_INFOS, LTX2_INFOS, LTX2_MSR_INFOS, LTX2_MSR_V2_INFOS, LTX2_SOL_INFOS
+from .ltx_core.model.transformer.sol_attention import SOL_ATTN_TAU_START_DEFAULT
 from .lora_utils import control_video_phase2_message
 from .ltx2_runtime import LTX2_OUTPAINTING_METHOD
 
@@ -511,10 +512,13 @@ class family_handler:
         distilled = pipeline_kind == "distilled"
         gemma_folder = _GEMMA4_FOLDER if ltx25 else _GEMMA_FOLDER
         gemma_files = (_GEMMA4_FILENAME, _GEMMA4_INT8_FILENAME) if ltx25 else (_GEMMA_FILENAME, _GEMMA_QUANTO_FILENAME)
+        base_infos = model_def.get("infos") or (
+            LTX2_25_INFOS if ltx25 else LTX2_MSR_V2_INFOS if msr_v2 else LTX2_MSR_INFOS if msr else LTX2_INFOS
+        )
         extra_model_def = {
             "ltx2_22B_class": base_model_type in LTX2_22B_CLASS or ltx25,
             "ltx2_edit_anything": editanything_ref,
-            "infos": model_def.get("infos", LTX2_25_INFOS if ltx25 else LTX2_MSR_V2_INFOS if msr_v2 else LTX2_MSR_INFOS if msr else LTX2_INFOS),
+            "infos": base_infos + LTX2_SOL_INFOS,
             "text_encoder_folder": gemma_folder,
             "text_encoder_URLs": [
                 build_hf_url("DeepBeepMeep/LTX-2", gemma_folder, gemma_files[0]),
@@ -536,6 +540,15 @@ class family_handler:
             "self_refiner": True,
             "self_refiner_max_plans": 2,
             "custom_settings": [_PROMPT_RELAY_CUSTOM_SETTING.copy()],
+            "custom_attention_modes": {
+                "sol": {"label": "Sol sparse attention, requires Triton and RTX 30xx or newer", "supports_sparsity": True},
+            },
+            "attention_sparsity": {
+                "label": "Start Tau (higher = more sparse/faster; lower = more faithful; End Tau = 0.8)",
+                "start": 0.0,
+                "end": 4.0,
+                "inc": 0.05,
+            },
             # "no_background_removal": True,
             "vae_block_size": 64,
             "keep_frames_video_guide_not_supported": True,
@@ -595,7 +608,7 @@ class family_handler:
                     "preserve_empty_prompt_lines": True,
                     "skip_video_guide_preprocess": True,
                     "NAG": True,
-                    "infos": model_def.get("infos", JOYAI_ECHO_INFOS),
+                    "infos": (model_def.get("infos") or JOYAI_ECHO_INFOS) + LTX2_SOL_INFOS,
                     "fps": 25,
                     "image_prompt_types_allowed": "TSV",
                     "prompt_infos": JOYAI_ECHO_PROMPT_INFOS,
@@ -1059,6 +1072,7 @@ class family_handler:
     def fix_settings(base_model_type, settings_version, model_def, ui_defaults):
         default_perturbation_layers = _default_perturbation_layers(base_model_type)
         pipeline_kind = model_def.get("ltx2_pipeline", "two_stage")
+        ui_defaults.setdefault("attention_sparsity", SOL_ATTN_TAU_START_DEFAULT)
         if _is_joyai_echo(base_model_type, model_def):
             ui_defaults.setdefault("resolution", "1280x720")
             ui_defaults.setdefault("video_length", 129)
@@ -1114,7 +1128,6 @@ class family_handler:
                 audio_prompt_type =audio_prompt_type.replace("L", "")
                 ui_defaults["audio_prompt_type"] = audio_prompt_type
 
-            
     @staticmethod
     def update_default_settings(base_model_type, model_def, ui_defaults):
         default_perturbation_layers = _default_perturbation_layers(base_model_type)
@@ -1127,6 +1140,7 @@ class family_handler:
                 "audio_prompt_type": "",
                 "perturbation_layers": default_perturbation_layers,
                 "guidance_phases": 2,
+                "attention_sparsity": SOL_ATTN_TAU_START_DEFAULT,
 	            }
         )
         ui_defaults.setdefault("audio_scale", 1.0)

--- a/models/ltx2/ltx_core/model/transformer/attention.py
+++ b/models/ltx2/ltx_core/model/transformer/attention.py
@@ -6,6 +6,7 @@ import torch
 from ...utils import rms_norm
 from shared.attention import pay_attention
 from .rope import LTXRopeType, apply_rotary_emb_inplace
+from .sol_attention import SOL_ATTN_HEAD_DIM, sol_attention
 
 memory_efficient_attention = None
 flash_attn_interface = None
@@ -281,15 +282,25 @@ class Attention(torch.nn.Module):
                 out = self.to_out(out)
                 return out
 
+        use_sol = (
+            not cross_attn
+            and mask is None
+            and NAG is None
+            and self.dim_head == SOL_ATTN_HEAD_DIM
+            and sol_attention.use_for_layer(q.shape[1], self.dim_head)
+        )
         qkv_list = [q, k, v]
         q = k = v = None
-        out = pay_attention(
-            qkv_list,
-            attention_mask=mask,
-            force_attention=force_attention,
-            version=attention_version,
-            recycle_q= True,
-        )
+        if use_sol:
+            out = sol_attention(qkv_list)
+        else:
+            out = pay_attention(
+                qkv_list,
+                attention_mask=mask,
+                force_attention=force_attention,
+                version=attention_version,
+                recycle_q=True,
+            )
         if self.to_gate_logits is not None:
             gate_logits = self.to_gate_logits(gate_input)
             gates = 2.0 * torch.sigmoid(gate_logits).to(dtype=out.dtype)

--- a/models/ltx2/ltx_core/model/transformer/model.py
+++ b/models/ltx2/ltx_core/model/transformer/model.py
@@ -8,6 +8,7 @@ from .adaln import AdaLayerNormSingle, adaln_embedding_coefficient
 from .attention import AttentionCallable, AttentionFunction
 from .modality import Modality
 from .rope import LTXRopeType
+from .sol_attention import first_modality, sol_attention
 from .transformer import BasicAVTransformerBlock, TransformerConfig, _apply_scale_shift
 from .transformer_args import (
     MultiModalTransformerArgsPreprocessor,
@@ -478,6 +479,10 @@ class LTXModel(torch.nn.Module):
 
         self._refresh_preprocessor_refs()
         self.interrupted = False
+        # Refresh the Sol-Attn policy (enabled state, per-step tau, one-time runtime validation).
+        sol_source = first_modality(video) or first_modality(audio)
+        if sol_source is not None:
+            sol_attention.begin_forward(sol_source.latent.device, sol_source.latent.dtype, video, audio)
         joint_pass = isinstance(video, (list, tuple)) or isinstance(audio, (list, tuple))
         if joint_pass:
             video_list = list(video) if isinstance(video, (list, tuple)) else [None] * len(audio)

--- a/models/ltx2/ltx_core/model/transformer/sol_attention.py
+++ b/models/ltx2/ltx_core/model/transformer/sol_attention.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+"""LTX2 policy for the bundled Sol-Attn kernels."""
+
+from __future__ import annotations
+
+import torch
+from mmgp import offload
+
+
+SOL_ATTN_THRESH_TYPE = "diag"
+SOL_ATTN_MIN_TOKENS = 8192
+SOL_ATTN_HEAD_DIM = 128
+SOL_ATTN_TAU_END = 0.8
+SOL_ATTN_TAU_START_DEFAULT = 1.3
+SOL_ATTN_TAU_START_KEY = "_sol_attention_sparsity"
+
+
+def first_modality(modality):
+    """Return the first non-None Modality (or the modality itself)."""
+    if modality is None:
+        return None
+    if isinstance(modality, (list, tuple)):
+        for item in modality:
+            if item is not None:
+                return item
+        return None
+    return modality
+
+
+def current_step_fraction(video, audio) -> float:
+    """Progress of the current denoising step in [0, 1] for the tau schedule."""
+    modality = first_modality(video) or first_modality(audio)
+    if modality is None:
+        return 1.0
+    if modality.step_index is not None and modality.sigma_schedule is not None:
+        total = max(len(modality.sigma_schedule) - 1, 1)
+        return min(max(float(modality.step_index) / total, 0.0), 1.0)
+    if modality.sigma is not None:
+        # Flow-matching sigmas start at 1.0 and end at 0, so sigma is a direct progress proxy.
+        value = float(modality.sigma.detach().max())
+        return min(max(value, 0.0), 1.0)
+    return 1.0
+
+
+class LTX2SolAttention:
+    def __init__(self):
+        self.enabled = False
+        self._runtime_validated = False
+        self._announced = False
+        self.sink_tokens = 0
+        self.tau = SOL_ATTN_TAU_END
+
+    def begin_forward(self, device, dtype, video=None, audio=None):
+        self.enabled = offload.shared_state.get("_attention") == "sol"
+        if not self.enabled:
+            return
+        tau_start = float(offload.shared_state.get(SOL_ATTN_TAU_START_KEY, SOL_ATTN_TAU_START_DEFAULT))
+        fraction = current_step_fraction(video, audio)
+        self.tau = SOL_ATTN_TAU_END + (tau_start - SOL_ATTN_TAU_END) * (1.0 - fraction)
+        if not self._runtime_validated:
+            from shared.sol_attn import validate_runtime
+
+            capability = validate_runtime(device, dtype)
+            self._runtime_validated = True
+            if not self._announced:
+                print(
+                    f"[LTX2] Sol-Attn enabled with Triton on SM{capability[0]}{capability[1]} "
+                    f"(tau start={tau_start:g} end={SOL_ATTN_TAU_END:g}, {SOL_ATTN_THRESH_TYPE})"
+                )
+                self._announced = True
+
+    def use_for_layer(self, tokens, head_dim):
+        return self.enabled and head_dim == SOL_ATTN_HEAD_DIM and tokens >= SOL_ATTN_MIN_TOKENS
+
+    def __call__(self, qkv_list):
+        query, key, value = qkv_list
+        qkv_list.clear()
+        from shared.sol_attn import sol_attn
+
+        output = sol_attn(query, key, value, tau=self.tau, thresh_type=SOL_ATTN_THRESH_TYPE,
+                          sink_start=0, sink_tokens=self.sink_tokens, int8_qk=True)
+        return output
+
+
+sol_attention = LTX2SolAttention()
+
+
+__all__ = [
+    "LTX2SolAttention",
+    "SOL_ATTN_HEAD_DIM",
+    "SOL_ATTN_MIN_TOKENS",
+    "SOL_ATTN_TAU_END",
+    "SOL_ATTN_TAU_START_DEFAULT",
+    "SOL_ATTN_TAU_START_KEY",
+    "current_step_fraction",
+    "first_modality",
+    "sol_attention",
+]


### PR DESCRIPTION
## What

Adds an optional **"sol" entry to Override Attention Mode for LTX2**, routing eligible video self-attention blocks through the bundled Sol-Attn Triton sparse kernels (`shared/sol_attn`). This is an experimental first integration — see *Validation* below.

When enabled, a **Start Tau** slider appears (default `1.3`): tau starts at that value on the first denoising step of each phase and decreases linearly to a fixed End Tau of `0.8`. Higher = more blocks take the sparse path = faster but less faithful; lower = denser = closer to full attention.

## Gating (automatic fallback to the normal backend)

Sol-Attn is used per self-attention block only when **all** of these hold; everything else (cross-attention, audio self-attention, masked attention, short sequences, unsupported GPUs) silently keeps the regular backend:

- self-attention (no cross-attn / mask / NAG)
- ≥ 8192 tokens and 128-dim heads
- bfloat16, Triton ≥ 3.6
- GPU capability in the kernel's supported set: SM86, SM89, SM90, SM100, SM120, SM121 (RTX 30/40/50 series, H100/H200, B100/B200, DGX Spark); the dropdown reports availability

## Files

- `models/ltx2/ltx_core/model/transformer/sol_attention.py` — new ~100-line policy object (tau schedule, gating, one-time runtime validation); kernel calls go to the `shared/sol_attn` interface
- `.../transformer/attention.py` — one branch in `Attention`: sol path when gated, else `pay_attention` as before
- `.../transformer/model.py` — per-forward policy refresh (device/dtype/step) in `LTXModel.forward`
- `models/ltx2/ltx2.py` — passes the Start Tau setting into the policy
- `models/ltx2/ltx2_handler.py` — registers the `sol` mode + sparsity slider in the UI
- `models/ltx2/infos.py` — help text for the new mode

## Validation

So far a single 30-second LTX 2.5 generation with `sol` enabled: **one 721-frame window (1920x1088 @ 24fps) on an RTX 5090** — a window size only possible with #2288 (*Sliding Window: allow window sizes up to 999 frames*). It runs end-to-end, but **facial features were not well preserved** — hence the experimental status. No A/B quality study has been done yet.

## Outlook

The same pattern (small policy object + one call-site branch on top of the shared kernels) is a good fit for other WanGP models with 128-dim heads and long windowed self-attention — **Wan (1.3B/14B) and HyVideo** are the most promising next candidates.
