### PR TITLE
Add support for more keywords and optional Python format specs to the output file name

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -111,6 +111,46 @@ Let's generate a simple text-to-video:
 - **Fixed Seed**: Reproducible results
 - **Use same seed + prompt**: Generate variations
 
+### Custom Output Filenames
+
+Generated files are named automatically by default (timestamp, seed and prompt). You can customize the name: in the **Misc** tab, fill the **Output Filename (Leave Blank for Auto Naming)** text box with a template. Placeholders are written in curly braces and replaced with the actual values of the current generation; anything else in the template is kept as literal text. Leave the box empty to keep the automatic naming.
+
+Formatting options:
+
+- a **Python format spec** can be appended to any placeholder to control the number formatting, e.g. `{scale:.2f}`, `{steps:.0f}`, `{fps:.0f}`
+- `{prompt(n)}` truncates the prompt to *n* characters
+- `{date(...)}` accepts date/time tokens: `YYYY` `YY` `MM` `DD` `HH` `hh` `mm` `ss`, with any separator among `- _ . : /` and the letters `h` (e.g. `{date(YYYY-MM-DD_HH-mm-ss)}` → `2025-01-15_14-30-45`)
+- unknown placeholders are rejected when the generation starts
+
+Supported placeholders:
+
+| Placeholder | Description |
+|---|---|
+| `{date}` | Timestamp, default format `YYYY-MM-DD-HHhMMmSSs` (e.g. `2025-01-15-14h30m45s`) |
+| `{date(YYYY-MM-DD_HH-mm-ss)}` | Timestamp with a custom format, see tokens above |
+| `{seed}` | Generation seed |
+| `{model}` (alias `{model_type}`) | Model type, e.g. `ltx2.5`, `wan1.3` |
+| `{resolution}` | Selected resolution label, e.g. `1280x720 (16:9)` |
+| `{width}` / `{height}` | Effective output dimensions in pixels (after spatial upsampling) |
+| `{video_length}` (alias `{frames}`) | Output frame count |
+| `{fps}` | Effective output fps (after temporal upsampling) |
+| `{scale}` | Spatial upsampling factor (`1` when no spatial upsampler is used) |
+| `{num_inference_steps}` (alias `{steps}`) | Number of inference steps |
+| `{prompt}` / `{prompt(50)}` | Prompt text, optionally truncated to the given number of characters |
+| `{flow_shift}` | Flow shift value |
+| `{guidance_scale}` (alias `{cfg}`) | Guidance scale |
+| `{teacache}` | TeaCache tag (`tc<multiplier>`, e.g. `tc1.00`), empty when TeaCache is disabled |
+| `{sliding_window_size}` / `{sliding_window_overlap}` | Sliding window size / overlap in frames |
+| `{temporal_upsampling}` / `{spatial_upsampling}` | Selected upsampler method, empty when unused |
+
+Examples:
+
+```
+{date(YYYY-MM-DD_HH-mm-ss)}_{seed}_{prompt(50)}, {num_inference_steps}
+{date}_{model}_seed{seed}_steps{steps}{teacache}_{width}x{height}x{frames}@{fps:.0f}_scale{scale:.2f}
+```
+
+
 ## Common Beginner Issues
 
 ### "Out of Memory" Errors

--- a/shared/utils/filename_formatter.py
+++ b/shared/utils/filename_formatter.py
@@ -9,6 +9,11 @@ Example usage:
     filename = FilenameFormatter.format_filename(template, settings)
     # Result: "2025-01-15-14h30m45s-A_beautiful_sunset_over_the_ocean-12345"
 
+    Placeholder syntax:
+        {key}                -> value from the settings
+        {key(arg)}           -> optional argument (date format, or max length for {prompt})
+        {key:fmt}            -> Python format spec applied to the value, e.g. {scale:.2f}, {steps:.0f}
+
 Date format examples:
     {date}                      -> 2025-01-15-14h30m45s (default)
     {date(YYYY-MM-DD)}          -> 2025-01-15
@@ -32,12 +37,22 @@ class FilenameFormatter:
     - {date(YYYY-MM-DD)} - date with custom format and separator
     - {date(YYYY-MM-DD_HH-mm-ss)} - date and time with custom separators
     - {seed} - generation seed
-    - {resolution} - video resolution (e.g., "1280x720")
+    - {model} or {model_type} - model type (e.g., "ltx2.5", "wan1.3")
+    - {resolution} - selected resolution (e.g., "1280x720 (16:9)")
+    - {width} / {height} - effective output dimensions (after spatial upsampling)
+    - {fps} - effective output fps (after temporal upsampling)
+    - {scale} - spatial upsampling factor (1 when no spatial upsampler is used)
     - {num_inference_steps} or {steps} - number of inference steps
     - {prompt} or {prompt(50)} - prompt text with optional max length
     - {flow_shift} - flow shift value
-    - {video_length} or {frames} - video length in frames
+    - {video_length} or {frames} - output frame count
     - {guidance_scale} or {cfg} - guidance scale value
+    - {teacache} - TeaCache tag (e.g., "tc1.00"), empty when TeaCache is disabled
+    - {sliding_window_size} / {sliding_window_overlap} - sliding window size/overlap in frames
+    - {temporal_upsampling} / {spatial_upsampling} - selected upsampler (empty when unused)
+
+    A Python format spec can be appended to any placeholder: {key:fmt}
+    (e.g., {scale:.2f}, {steps:.0f}, {fps:.0f}).
 
     Date format tokens:
     - YYYY: 4-digit year (2025)
@@ -60,18 +75,22 @@ class FilenameFormatter:
     ALLOWED_KEYS = {
         'date', 'seed', 'resolution', 'num_inference_steps', 'steps',
         'prompt', 'flow_shift', 'video_length', 'frames',
-        'guidance_scale', 'cfg'
+        'guidance_scale', 'cfg',
+        'model', 'model_type', 'fps', 'scale', 'width', 'height',
+        'teacache', 'sliding_window_size', 'sliding_window_overlap',
+        'temporal_upsampling', 'spatial_upsampling'
     }
 
     # Map aliases to actual setting keys
     KEY_ALIASES = {
         'steps': 'num_inference_steps',
         'frames': 'video_length',
-        'cfg': 'guidance_scale'
+        'cfg': 'guidance_scale',
+        'model': 'model_type'
     }
 
-    # Pattern to match placeholders: {key}, {key(arg)}, or {key(%format)}
-    PLACEHOLDER_PATTERN = re.compile(r'\{(\w+)(?:\(([^)]*)\))?\}')
+    # Pattern to match placeholders: {key}, {key(arg)}, {key:fmt}, or {key(arg):fmt}
+    PLACEHOLDER_PATTERN = re.compile(r'\{(\w+)(?:\(([^)]*)\))?(:([^}]*))?\}')
 
     # Date token to strftime mapping (order matters - longer tokens first)
     DATE_TOKENS = [
@@ -215,16 +234,42 @@ class FilenameFormatter:
         def replace_placeholder(match):
             key = match.group(1)
             arg = match.group(2)  # Optional argument in parentheses
+            fmt_spec = match.group(4)  # Optional Python format spec (e.g. ".2f"), None when absent
 
             # Handle date specially
             if key == 'date':
                 return self._format_date(arg)
+
+            # Teacache: composed of the skip-steps cache type and its multiplier
+            # (e.g. "tc1.00"); empty when the cache is disabled
+            if key == 'teacache':
+                cache_type = settings.get('skip_steps_cache_type')
+                if not cache_type:
+                    return ''
+                multiplier = settings.get('skip_steps_multiplier')
+                try:
+                    return self._sanitize_for_filename(f"{cache_type}{float(multiplier):.2f}")
+                except (TypeError, ValueError):
+                    return self._sanitize_for_filename(str(cache_type))
 
             # Resolve aliases
             actual_key = self.KEY_ALIASES.get(key, key)
 
             # Get value from settings
             value = settings.get(actual_key)
+
+            # Apply Python format spec if requested (e.g. {scale:.2f})
+            if fmt_spec is not None:
+                try:
+                    if value is None:
+                        value = ''
+                    elif isinstance(value, (int, float)) and not isinstance(value, bool):
+                        value = format(value, fmt_spec)
+                    else:
+                        value = format(str(value), fmt_spec)
+                except (ValueError, TypeError):
+                    value = '' if value is None else str(value)
+                return self._sanitize_for_filename(value)
 
             # Convert to string
             if value is None:

--- a/wgp.py
+++ b/wgp.py
@@ -8287,6 +8287,18 @@ def generate_media(
                 if overridden_inputs is not None: inputs.update(overridden_inputs)
                 if scheduler_active and output_frame_count is not None:
                     inputs["video_length"] = output_frame_count
+                # Expose the effective output parameters to the filename template: they are
+                # function locals (not generate_media arguments), so they are not part of
+                # the settings dict built from the function arguments above.
+                inputs["fps"] = output_fps
+                out_height, out_width = height, width
+                if not audio_only and is_image and sample is not None:
+                    out_height, out_width = sample.shape[-2], sample.shape[-1]
+                elif not audio_only and not is_image and frames_already_processed:
+                    out_height, out_width = frames_already_processed[-1].shape[-2], frames_already_processed[-1].shape[-1]
+                inputs["width"] = int(out_width)
+                inputs["height"] = int(out_height)
+                inputs["scale"] = round(int(out_height) / int(height), 2) if height else 1
                 if len(output_filename):
                     from shared.utils.filename_formatter import FilenameFormatter
                     file_name = FilenameFormatter.format_filename(output_filename, inputs)                    
@@ -12584,7 +12596,7 @@ def generate_media_tab(update_form = False, state_dict = None, ui_defaults = Non
                     )
                     attention_sparsity = setting_slider("attention_sparsity", visible=custom_attention_modes.get(selected_attention, {}).get("supports_sparsity", False))
                     with gr.Column():
-                        gr.Markdown('<B>Customize the Output Filename using Settings Values (<I>date, seed, resolution, num_inference_steps, prompt, flow_shift, video_length, guidance_scale</I>). For Instance:<BR>"<I>{date(YYYY-MM-DD_HH-mm-ss)}_{seed}_{prompt(50)}, {num_inference_steps}</I>"</B>')
+                        gr.Markdown('<B>Customize the Output Filename using Settings Values (<I>date, seed, model, resolution, width, height, video_length, fps, scale, steps, prompt, flow_shift, guidance_scale, teacache, sliding_window_size, sliding_window_overlap, temporal_upsampling, spatial_upsampling</I>). Each placeholder can take a Python format spec, e.g. <I>{scale:.2f}</I> (full list and examples in <I>docs/GETTING_STARTED.md</I>). For Instance:<BR>"<I>{date(YYYY-MM-DD_HH-mm-ss)}_{seed}_{prompt(50)}, {num_inference_steps}</I>"</B>')
                         output_filename = gr.Text( label= " Output Filename ( Leave Blank for Auto Naming)", value= ui_get("output_filename"))
 
                     config_groups = get_model_config_groups(model_type, model_def)


### PR DESCRIPTION
## What

Extends the output filename template (Misc tab → *Output Filename (Leave Blank for Auto Naming)*) with new placeholders and number-formatting support:

**New placeholders**

| Placeholder | Value |
|---|---|
| `{model}` (alias `{model_type}`) | model type, e.g. `ltx2.5` |
| `{fps}` | **effective** output fps (after temporal upsampling) |
| `{scale}` | spatial upsampling factor (`1` when unused) |
| `{width}` / `{height}` | **effective** output dimensions (after spatial upsampling) |
| `{teacache}` | TeaCache tag, e.g. `tc1.00`; empty when TeaCache is disabled |
| `{sliding_window_size}` / `{sliding_window_overlap}` | sliding window size/overlap |
| `{temporal_upsampling}` / `{spatial_upsampling}` | selected upsampler (empty when unused) |

**Python format specs**: any placeholder can take a standard Python format spec — `{scale:.2f}`, `{fps:.0f}`, `{steps:.0f}`, even `{prompt:.20s}` for strings. Invalid specs fall back to the plain value.

**Documentation**: new *Custom Output Filenames* section in `docs/GETTING_STARTED.md` — where/how to use the template, a table of **all** supported placeholders (old + new) with descriptions, the `{date(...)}` token syntax, and examples. The in-UI hint above the text box is updated to list the new keys.

## Why

The existing set couldn't express "what is this file": model, and the *actual* output resolution/fps/scale after upscaling were not available (`{resolution}` is the selected-resolution label, `{video_length}` only the frames). This makes names like:

```
{date}_{model}_seed{seed}_steps{steps}{teacache}_{width}x{height}x{frames}@{fps:.0f}_scale{scale:.2f}
```

possible without any hard-coded default.

## Notes

- Purely additive: the auto-naming default is unchanged and all existing templates keep working (the placeholder grammar is backward compatible, including `{date(YYYY-MM-DD_HH-mm-ss)}` with colons inside the parentheses).
- The effective values are exposed to the template right where the existing `inputs["video_length"]` override lives, so they reflect the final output of each sliding-window iteration.
- Unknown placeholders are still rejected with a clear error listing all allowed keys.

## Files

- `shared/utils/filename_formatter.py` (+57/−7): new keys, `{key:fmt}` support, Teacache composition, help text
- `wgp.py` (+14/−1): expose `fps`/`width`/`height`/`scale` to the template; updated UI hint
- `docs/GETTING_STARTED.md` (+40): the *Custom Output Filenames* section
