### PR TITLE
MiniMax H3: negative prompt through NAG

### DIFF
--- a/models/minimax_h3/minimax_h3_handler.py
+++ b/models/minimax_h3/minimax_h3_handler.py
@@ -370,7 +370,7 @@ class family_handler:
                 "profiles_dir": [VIGGLE_ARCHITECTURE],
                 "infos": VIGGLE_INFOS,
                 "prompt_infos": "Viggle uses a fixed prompt. Prepare the character replacement in the Edited Reference Frame; generation prompt text is ignored.",
-                "text_encoder_URLs": [], "text_encoder_folder": None, "system_configs": {},
+                "text_encoder_URLs": [], "text_encoder_folder": None, "system_configs": {}, "NAG": False, "no_negative_prompt": True,
                 "prompt_enhancer_def": {"selection": [], "labels": {}, "default": ""},
                 "image_outputs": False, "sliding_window": True, "video_continuation": False,
                 "sliding_window_size_locked": True,
@@ -466,7 +466,8 @@ class family_handler:
                 "inc": 0.05,
             },
             "sample_solvers": [("Euler", "euler")] if pdd else [("Euler", "euler"), ("RES Multistep", "res_multistep"), ("Ralston 2S (~2x slower)", "ralston_2s")],
-            "no_negative_prompt": True,
+            "NAG": True,
+            "no_negative_prompt": False,
             "returns_audio": True,
             "multimedia_generation": True,
             "image_end_frame_position": True,
@@ -934,6 +935,9 @@ class family_handler:
             "audio_prompt_type": "",
             "video_prompt_type": "",
             "image_mode": 0,
+            "NAG_scale": 1.0,
+            "NAG_tau": 3.5,
+            "NAG_alpha": 0.5,
         })
         if reference_mode:
             ui_defaults.update({"image_refs_relative_size": 100, "remove_background_images_ref": 0})

--- a/models/minimax_h3/pipeline.py
+++ b/models/minimax_h3/pipeline.py
@@ -473,15 +473,23 @@ class MiniMaxH3Pipeline:
                 digest.update(repr(tuple(item["timestamps"])).encode())
         return "minimax_h3", str(self.dtype), prompt, digest.digest()
 
-    def _encode_prompt(self, prompt, presentation):
+    def _encode_prompt(self, prompt, presentation, min_tokens=0):
         if self.fixed_prompt is not None:
             return self.fixed_prompt.prompt_embeds.to(device=self.device, dtype=self.dtype), self.fixed_prompt.text_token_tags
 
         def encode_fn(prompts):
-            return [self.text_encoder.encode(prompts[0], presentation, self.device, self.dtype)]
+            return [self.text_encoder.encode(prompts[0], presentation, self.device, self.dtype, min_tokens)]
 
-        cache_key = self._prompt_cache_key(prompt, presentation)
+        cache_key = self._prompt_cache_key(prompt, presentation) + ((min_tokens,) if min_tokens else ())
         return self.text_encoder_cache.encode(encode_fn, prompt, device=self.device, cache_keys=cache_key)[0]
+
+    def _nag_payload(self, negative_prompt, NAG_scale, NAG_tau, NAG_alpha, text_tags):
+        negative_prompt = (negative_prompt or "").strip()
+        if float(NAG_scale) <= 1.0 or not negative_prompt or self.fixed_prompt is not None or self.audio_only:
+            return None
+        # Padded to the positive caption's token count: a shorter negative caption guides by its length alone.
+        context, _ = self._encode_prompt(negative_prompt, [], min_tokens=text_tags.numel())
+        return {"scale": float(NAG_scale), "tau": float(NAG_tau), "alpha": float(NAG_alpha), "context": context}
 
     def _configure_tiling(self, _tile_size):
         self.vae.enable_tiling(tile_sample_min_height=256, tile_sample_min_width=256)
@@ -657,7 +665,8 @@ class MiniMaxH3Pipeline:
                  sample_solver="euler", attention_sparsity=1.0,
                  guide_phases=1, switch_threshold=H3_PHASE_2_NOISE_LEVEL_START_DEFAULT, loras_slists=None, loras_selected=None, set_progress_status=None,
                  starting_sigma=None, preserve_input_mask_values=False, refinement_mode=False,
-                 custom_settings=None, duration_seconds=None, verbose_level=0, dialogue_segment=False, **kwargs):
+                 custom_settings=None, duration_seconds=None, verbose_level=0, dialogue_segment=False,
+                 n_prompt="", NAG_scale=1.0, NAG_tau=3.5, NAG_alpha=0.5, **kwargs):
         if self.audio_only and H3_DIALOGUE_GENERATION and not dialogue_segment and is_dialogue_prompt(input_prompt):
             self._early_stop = False
             return generate_dialogue(
@@ -722,6 +731,8 @@ class MiniMaxH3Pipeline:
         video_to_video = control_video and not audio_from_control_video and (float(denoising_strength) < 1.0 or input_masks is not None)
         if grouped_masked_denoising and video_to_video and input_masks is not None and not preserve_input_mask_values and offload.shared_state.get("_attention") == "sol":
             raise ValueError("MiniMax H3 Grouped Rows mask denoising is not compatible with Sol Attention; select Shared Timestep or another attention mode")
+        if float(NAG_scale) > 1.0 and (n_prompt or "").strip() and offload.shared_state.get("_attention") == "sol":
+            raise ValueError("MiniMax H3 NAG is not compatible with Sol Attention; select another attention mode or set NAG Scale to 1")
 
         waveform = self._waveform(input_waveform, input_waveform_sample_rate)
         history_waveform = None
@@ -888,6 +899,7 @@ class MiniMaxH3Pipeline:
         if set_progress_status is not None:
             set_progress_status("Encoding H3 prompt and references")
         context, text_tags = self._encode_prompt(input_prompt, presentation)
+        nag = self._nag_payload(n_prompt, NAG_scale, NAG_tau, NAG_alpha, text_tags)
         self._check_abort()
         self._use_transformer()
         context = self.transformer.preprocess_text_embeds(context)
@@ -918,7 +930,7 @@ class MiniMaxH3Pipeline:
                    "cond_audio_rows": cond_audio_rows, "frame_count": aligned_target_frames, "text_token_tags": text_tags,
                    "fps": fps, "target_audio_condition_latents": target_audio_condition_latents,
                    "target_video_condition_frames": target_video_condition_frames,
-                   "attention_sparsity": float(attention_sparsity)}
+                   "attention_sparsity": float(attention_sparsity), "NAG": nag}
 
         if starting_sigma is None:
             base_sigmas = torch.linspace(1.0, 0.0, int(sampling_steps) + 1, dtype=torch.float32)
@@ -1216,6 +1228,7 @@ class MiniMaxH3Pipeline:
             if set_progress_status is not None:
                 set_progress_status("Encoding H3 phase 2 prompt and references")
             context, text_tags = self._encode_prompt(input_prompt, phase_2_presentation)
+            payload["NAG"] = self._nag_payload(n_prompt, NAG_scale, NAG_tau, NAG_alpha, text_tags)
             self._check_abort()
             phase_2_generator = torch.Generator(device="cpu").manual_seed(int(seed))
             phase_2_sigmas_video = torch.tensor((float(switch_threshold), *H3_PHASE_2_SIGMAS[1:]), dtype=torch.float32, device=self.device)
@@ -1413,6 +1426,7 @@ class MiniMaxH3Pipeline:
                 set_progress_status(f"Audio Refinement Extra Phase ({refinement_steps} steps, denoising {H3_AUDIO_REFINEMENT_DENOISE:g})")
             self._use_shared_components()
             context, text_tags = self._encode_prompt(input_prompt, [])
+            nag = self._nag_payload(n_prompt, NAG_scale, NAG_tau, NAG_alpha, text_tags)
             self._check_abort()
             self._use_transformer()
             context = self.transformer.preprocess_text_embeds(context)
@@ -1423,7 +1437,7 @@ class MiniMaxH3Pipeline:
                        "cond_audio_rows": None, "frame_count": aligned_target_frames, "text_token_tags": text_tags,
                        "fps": fps, "target_audio_condition_latents": 0,
                        "target_video_condition_frames": target_video_condition_frames,
-                       "attention_sparsity": float(attention_sparsity)}
+                       "attention_sparsity": float(attention_sparsity), "NAG": nag}
             active_loras = list(getattr(self.transformer, "_loras_active_adapters", ()))
             lora_scaling = dict(getattr(self.transformer, "_loras_scaling", {}) or {})
             lora_step = getattr(self.transformer, "_lora_step_no", 0)

--- a/models/minimax_h3/text_encoder.py
+++ b/models/minimax_h3/text_encoder.py
@@ -153,8 +153,9 @@ class MiniMaxH3TextEncoder(nn.Module):
         add_text(prompt)
         return entries or [TEXT_PAD]
 
-    def encode(self, prompt, items, device, dtype):
+    def encode(self, prompt, items, device, dtype, min_tokens=0):
         entries = self._presentation(prompt, items)
+        entries += [TEXT_PAD] * (min_tokens - len(entries))
         token_ids = []
         visual_specs = []
         for entry in entries:

--- a/models/minimax_h3/transformer.py
+++ b/models/minimax_h3/transformer.py
@@ -128,17 +128,10 @@ def _nag_guidance(x_pos, x_neg, NAG):
     return x_guidance.to(dtype)
 
 
-def _nag_guided_rows(layout, audio_start, audio_t, fixed_video_rows, device):
-    # The rows being generated: target audio and video, less the latents that carry supplied input.
+def _nag_guided_rows(layout, device):
+    # Every row after the caption, supplied input included (start image, keyframes, continuation), as Wan and LTX-2 guide.
     mask = torch.zeros(layout.sequence_length, dtype=torch.bool, device=device)
-    mask[audio_start:] = True
-    condition_latents = layout.num_target_condition_audio_latents
-    mask[audio_start:audio_start + condition_latents] = False
-    mask[audio_start + audio_t:audio_start + audio_t + condition_latents] = False
-    if layout.num_target_condition_video_rows:
-        mask[-layout.num_target_condition_video_rows:] = False
-    video_start = audio_start + audio_t * 2
-    mask[video_start:video_start + fixed_video_rows] = False
+    mask[layout.text_indices.numel():] = True
     return mask, mask.nonzero().flatten()
 
 
@@ -663,7 +656,7 @@ class MiniMaxH3Model(nn.Module):
         payload["layout_signature"], payload["layout"] = signature, layout
         return layout
 
-    def _prepare_nag(self, NAG, layout, timestep_indices, audio_start, audio_t, fixed_video_rows, device, dtype):
+    def _prepare_nag(self, NAG, layout, timestep_indices, device, dtype):
         if NAG["context"].shape[-1] != self.hidden_size:
             NAG["context"] = self.preprocess_text_embeds(NAG["context"])
         caption_len = NAG["context"].shape[1]
@@ -673,7 +666,7 @@ class MiniMaxH3Model(nn.Module):
             positions[:, 0] = torch.arange(caption_len, dtype=torch.float32, device="cpu")
             frequencies = positions.unsqueeze(-1) * self.rope.inv_freq.detach().cpu().view(1, 1, -1)
             NAG["rope"] = _rope_table(torch.cat(frequencies.unbind(dim=1), dim=-1), dtype).to(device)
-        mask, rows = _nag_guided_rows(layout, audio_start, audio_t, fixed_video_rows, device)
+        mask, rows = _nag_guided_rows(layout, device)
         return dict(NAG, hidden=NAG["context"][0].to(device=device, dtype=dtype, copy=True), mask=mask, rows=rows,
                     row=int(timestep_indices[0]) * 3 + MINIMAX_H3_TEXT_TAG, text_len=layout.text_indices.numel())
 
@@ -815,8 +808,7 @@ class MiniMaxH3Model(nn.Module):
         audio_start = video_start - target_audio_rows
         NAG = payload.get("NAG")
         if NAG is not None:
-            fixed_video_rows = target_video_fixed_rows if target_video_order is not None and target_video_mask_active else 0
-            NAG = self._prepare_nag(NAG, layout, timestep_indices, audio_start, audio_t, fixed_video_rows, device, dtype)
+            NAG = self._prepare_nag(NAG, layout, timestep_indices, device, dtype)
         self.sol_attention.begin_forward(layout, device, dtype, payload["attention_sparsity"], target_video_order is not None)
         if vdn := getattr(self.blocks[0].attn, "vdn", None):
             for block in self.blocks:

--- a/models/minimax_h3/transformer.py
+++ b/models/minimax_h3/transformer.py
@@ -112,6 +112,36 @@ def _rope_table(angles, dtype):
     return torch.stack((angles.cos(), angles.sin()), dim=-1).unsqueeze(0).unsqueeze(2).to(dtype)
 
 
+def _nag_guidance(x_pos, x_neg, NAG):
+    # NAG over (rows, features) as models/flux/math.py computes it, in float32: the scale amplifies half-precision rounding.
+    dtype = x_pos.dtype
+    x_pos, x_guidance = x_pos.float(), x_neg.float()
+    nag_scale, nag_tau, nag_alpha = NAG["scale"], NAG["tau"], NAG["alpha"]
+    x_guidance.mul_(1 - nag_scale).add_(x_pos, alpha=nag_scale)
+    norm_positive = torch.norm(x_pos, p=1, dim=-1, keepdim=True)
+    norm_guidance = torch.norm(x_guidance, p=1, dim=-1, keepdim=True)
+    scale = norm_guidance / norm_positive
+    torch.nan_to_num(scale, nan=10.0, posinf=10.0, neginf=10.0, out=scale)
+    x_guidance.mul_(torch.where(scale > nag_tau, 1 / (norm_guidance + 1e-7) * norm_positive * nag_tau, 1.0))
+    del norm_positive, norm_guidance, scale
+    x_guidance.mul_(nag_alpha).add_(x_pos, alpha=1 - nag_alpha)
+    return x_guidance.to(dtype)
+
+
+def _nag_guided_rows(layout, audio_start, audio_t, fixed_video_rows, device):
+    # The rows being generated: target audio and video, less the latents that carry supplied input.
+    mask = torch.zeros(layout.sequence_length, dtype=torch.bool, device=device)
+    mask[audio_start:] = True
+    condition_latents = layout.num_target_condition_audio_latents
+    mask[audio_start:audio_start + condition_latents] = False
+    mask[audio_start + audio_t:audio_start + audio_t + condition_latents] = False
+    if layout.num_target_condition_video_rows:
+        mask[-layout.num_target_condition_video_rows:] = False
+    video_start = audio_start + audio_t * 2
+    mask[video_start:video_start + fixed_video_rows] = False
+    return mask, mask.nonzero().flatten()
+
+
 class TimeEmbedder(nn.Module):
     def __init__(self, freq_dim, hidden, out, dtype=None, device=None):
         super().__init__()
@@ -186,11 +216,9 @@ class Attention(nn.Module):
             from .vdn_attention import VDNHybridAttention
             self.vdn = VDNHybridAttention(hidden, heads, head_dim, dtype=dtype, device=device)
 
-    def forward(self, x_list, rope=None, transformer_options=None):
+    def _qkv(self, x_list, rope, use_sol):
         x = _take(x_list)
-        vdn_input = x if hasattr(self, "vdn") else None
         seq_len = x.shape[0]
-        use_sol = not hasattr(self, "vdn") and self.sol_attention is not None and self.sol_attention.use_for_layer(seq_len)
         split_qkv = hasattr(self, "q_proj")
         if split_qkv:
             query = self.q_proj(x).view(1, seq_len, self.heads, self.head_dim)
@@ -230,11 +258,38 @@ class Attention(nn.Module):
                 first.mul_(cosine).addcmul_(second, sine, value=-1)
                 second.mul_(cosine).addcmul_(scratch, sine)
             del scratch, tensor, first, second
+        return qkv_list, raw_qkv
+
+    def _nag_attention(self, qkv_list, NAG):
+        # Negative branch, built as flux builds it: the negative caption's keys and values take the place of the prompt's.
+        # Its query is the caption itself, which keeps evolving through the blocks, followed by the guided rows.
+        query_neg, key_neg, value_neg = NAG.pop("qkv")
+        query, key, value = qkv_list
+        text_len, rows, caption_len = NAG["text_len"], NAG["rows"], query_neg.shape[1]
+        qkv_neg = [torch.cat((query_neg, query[:, rows]), dim=1), torch.cat((key_neg, key[:, text_len:]), dim=1),
+                   torch.cat((value_neg, value[:, text_len:]), dim=1)]
+        del query_neg, key_neg, value_neg, query, key, value
+        x_neg = pay_attention(qkv_neg, recycle_q=True)
+        NAG["x"] = self.out_proj(x_neg[0, :caption_len].reshape(caption_len, -1))
+        return x_neg[0, caption_len:].reshape(rows.numel(), -1)
+
+    def forward(self, x_list, rope=None, transformer_options=None, NAG=None):
+        seq_len = x_list[0].shape[0]
+        vdn_input = x_list[0] if hasattr(self, "vdn") else None
+        use_sol = not hasattr(self, "vdn") and self.sol_attention is not None and self.sol_attention.use_for_layer(seq_len)
+        qkv_list, raw_qkv = self._qkv(x_list, rope, use_sol)
+        if NAG is not None:
+            NAG["qkv"], NAG["raw"] = self._qkv([NAG["x"]], NAG["rope"], False)
         if hasattr(self, "vdn"):
             x_handoff, raw_handoff, softmax_handoff = [vdn_input], list(raw_qkv), qkv_list
-            vdn_input = raw_qkv = qkv_list = query = key = value = None
-            return self.vdn(x_handoff, raw_handoff, softmax_handoff, self.out_proj)
+            vdn_input = raw_qkv = qkv_list = None
+            return self.vdn(x_handoff, raw_handoff, softmax_handoff, self.out_proj, NAG)
+        x_neg = None if NAG is None else self._nag_attention(qkv_list, NAG)
         attention = pay_attention(qkv_list, recycle_q=True) if self.sol_attention is None else self.sol_attention(qkv_list, use_sol)
+        if x_neg is not None:
+            rows = NAG["rows"]
+            attention[0, rows] = _nag_guidance(attention[0, rows].flatten(1), x_neg, NAG).view(-1, self.heads, self.head_dim)
+            del x_neg
         output = attention.reshape(seq_len, -1)
         return self.out_proj(output)
 
@@ -339,20 +394,33 @@ class DiTBlock(nn.Module):
             hidden.copy_(branch)
         return hidden, signature
 
-    def forward(self, x_list, temb, segments, rope, residual_signature_elements=0):
+    def _advance_caption(self, NAG, gate_msa, shift_mlp, scale_mlp, gate_mlp):
+        caption = [(0, NAG["hidden"].shape[0], NAG["row"])]
+        hidden = _gated_residual([NAG.pop("hidden")], [gate_msa], [NAG.pop("x")], caption)
+        h_list = [_modulate(self.norm2(hidden), [shift_mlp, scale_mlp], caption)]
+        NAG["hidden"] = _gated_residual([hidden], [gate_mlp], [self.mlp(h_list)], caption)
+
+    def forward(self, x_list, temb, segments, rope, residual_signature_elements=0, NAG=None):
         residual_list = [_take(x_list)]
         shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = self.adaln_proj(temb)
+        if NAG is not None:
+            # The negative caption goes through the block as the prompt's text rows do, with their modulation.
+            NAG["x"] = _modulate(self.norm1(NAG["hidden"]), [shift_msa, scale_msa], [(0, NAG["hidden"].shape[0], NAG["row"])])
         h_list = [_modulate(self.norm1(residual_list[0]), [shift_msa, scale_msa], segments)]
         if not residual_signature_elements:
-            residual_list = [_gated_residual(residual_list, [gate_msa], [self.attn(h_list, rope=rope)], segments)]
+            residual_list = [_gated_residual(residual_list, [gate_msa], [self.attn(h_list, rope=rope, NAG=NAG)], segments)]
+            if NAG is not None:
+                self._advance_caption(NAG, gate_msa, shift_mlp, scale_mlp, gate_mlp)
             h_list = [_modulate(self.norm2(residual_list[0]), [shift_mlp, scale_mlp], segments)]
             return _gated_residual(residual_list, [gate_mlp], [self.mlp(h_list)], segments)
 
         hidden = _take(residual_list)
         signature_stride = max(1, math.ceil(hidden.numel() / residual_signature_elements))
-        branch = self.attn(h_list, rope=rope)
+        branch = self.attn(h_list, rope=rope, NAG=NAG)
         hidden, signature = self._gated_branch(hidden, gate_msa.to(hidden.dtype), branch, segments, signature_stride)
         del branch
+        if NAG is not None:
+            self._advance_caption(NAG, gate_msa, shift_mlp, scale_mlp, gate_mlp)
         h_list = [_modulate(self.norm2(hidden), [shift_mlp, scale_mlp], segments)]
         branch = self.mlp(h_list)
         hidden, signature = self._gated_branch(hidden, gate_mlp.to(hidden.dtype), branch, segments, signature_stride, signature)
@@ -595,6 +663,20 @@ class MiniMaxH3Model(nn.Module):
         payload["layout_signature"], payload["layout"] = signature, layout
         return layout
 
+    def _prepare_nag(self, NAG, layout, timestep_indices, audio_start, audio_t, fixed_video_rows, device, dtype):
+        if NAG["context"].shape[-1] != self.hidden_size:
+            NAG["context"] = self.preprocess_text_embeds(NAG["context"])
+        caption_len = NAG["context"].shape[1]
+        if NAG.get("rope") is None:
+            # Caption rows take the packed sequence's text positions, (index, 0, 0).
+            positions = torch.zeros(caption_len, 3, dtype=torch.float32, device="cpu")
+            positions[:, 0] = torch.arange(caption_len, dtype=torch.float32, device="cpu")
+            frequencies = positions.unsqueeze(-1) * self.rope.inv_freq.detach().cpu().view(1, 1, -1)
+            NAG["rope"] = _rope_table(torch.cat(frequencies.unbind(dim=1), dim=-1), dtype).to(device)
+        mask, rows = _nag_guided_rows(layout, audio_start, audio_t, fixed_video_rows, device)
+        return dict(NAG, hidden=NAG["context"][0].to(device=device, dtype=dtype, copy=True), mask=mask, rows=rows,
+                    row=int(timestep_indices[0]) * 3 + MINIMAX_H3_TEXT_TAG, text_len=layout.text_indices.numel())
+
     def _time_embedding(self, timesteps, table=None):
         if not self.use_adaln_curves:
             return self.time_embedder(timesteps)
@@ -731,6 +813,10 @@ class MiniMaxH3Model(nn.Module):
         del adaln_indices, changes
         target_audio_rows = audio_t * 2
         audio_start = video_start - target_audio_rows
+        NAG = payload.get("NAG")
+        if NAG is not None:
+            fixed_video_rows = target_video_fixed_rows if target_video_order is not None and target_video_mask_active else 0
+            NAG = self._prepare_nag(NAG, layout, timestep_indices, audio_start, audio_t, fixed_video_rows, device, dtype)
         self.sol_attention.begin_forward(layout, device, dtype, payload["attention_sparsity"], target_video_order is not None)
         if vdn := getattr(self.blocks[0].attn, "vdn", None):
             for block in self.blocks:
@@ -742,12 +828,12 @@ class MiniMaxH3Model(nn.Module):
                 h_list = [hidden]
                 hidden = None
                 block_temb = ref2va_temb if ref2va_temb is not None and self.hybrid_ref2va_blocks[0] <= block_index <= self.hybrid_ref2va_blocks[1] else temb
-                hidden = block(h_list, block_temb, segments, rope)
+                hidden = block(h_list, block_temb, segments, rope, NAG=NAG)
         else:
             self._check_interrupt()
             block_temb = ref2va_temb if ref2va_temb is not None and self.hybrid_ref2va_blocks[0] == 0 else temb
             hidden, signature = self.blocks[0]([hidden], block_temb, segments, rope,
-                                                residual_signature_elements=first_block_cache.MAX_SIGNATURE_ELEMENTS)
+                                                residual_signature_elements=first_block_cache.MAX_SIGNATURE_ELEMENTS, NAG=NAG)
             if first_block_cache.should_compute(signature):
                 head_output = first_block_cache.capture_head_output(hidden[audio_start:])
                 for block_index in range(1, len(self.blocks)):
@@ -755,7 +841,7 @@ class MiniMaxH3Model(nn.Module):
                     block_temb = ref2va_temb if ref2va_temb is not None and self.hybrid_ref2va_blocks[0] <= block_index <= self.hybrid_ref2va_blocks[1] else temb
                     h_list = [hidden]
                     hidden = None
-                    hidden = self.blocks[block_index](h_list, block_temb, segments, rope)
+                    hidden = self.blocks[block_index](h_list, block_temb, segments, rope, NAG=NAG)
                 first_block_cache.store_tail_residual(hidden[audio_start:], head_output)
             else:
                 first_block_cache.apply_tail_residual(hidden[audio_start:])

--- a/models/minimax_h3/vdn_attention.py
+++ b/models/minimax_h3/vdn_attention.py
@@ -336,26 +336,71 @@ class VDNHybridAttention(nn.Module):
         if not self.use_triton:
             _notify_slow()
 
-    def forward(self, x_handoff, raw_qkv, softmax_qkv, original_out):
+    def forward(self, x_handoff, raw_qkv, softmax_qkv, original_out, NAG=None):
         x = x_handoff.pop()
         video = slice(self.video_start, x.shape[0])
-        local = self._window_softmax(softmax_qkv)
+        local = self._window_softmax(softmax_qkv, NAG)
         local.mul_(self.softmax_gate(x))
         output = original_out(local.reshape(x.shape[0], -1))
         del local
+        if NAG is not None:
+            caption = NAG["x"]
+            NAG["x"] = original_out(NAG.pop("attention").mul_(self.softmax_gate(caption)).reshape(caption.shape[0], -1))
         text_idx = self.text_indices.to(x.device)
         query, key, value = raw_qkv
         raw_qkv.clear()
         video_raw = [query[video], key[video], value[video]]
         text_raw = [key[text_idx], value[text_idx]]
         query = key = value = None
+        if NAG is not None:
+            # The negative output is assembled as the positive one is, from both halves, then guided once.
+            _, key_neg, value_neg = NAG.pop("raw")
+            branch_neg = self.linear_attention(x[video], list(video_raw), self.frames, self.tokens_per_frame, self.frame_size,
+                                               self.bounds, caption, [key_neg, value_neg], self.use_triton)
+            del caption, key_neg, value_neg
         branch = self.linear_attention(x[video], video_raw, self.frames,
                                        self.tokens_per_frame, self.frame_size, self.bounds, x[text_idx],
                                        text_raw, self.use_triton)
         output[video].add_(self.to_out_linear(branch))
+        if NAG is not None:
+            from .transformer import _nag_guidance
+
+            rows = NAG["rows"]
+            if "video_rows" not in NAG:
+                in_video = rows >= self.video_start
+                NAG["video_rows"] = in_video.nonzero().flatten(), rows[in_video] - self.video_start
+            output_neg = original_out(NAG.pop("local").mul_(self.softmax_gate(x[rows])).reshape(rows.numel(), -1))
+            guided_video, branch_rows = NAG["video_rows"]
+            output_neg[guided_video] += self.to_out_linear(branch_neg[branch_rows])
+            del branch_neg
+            output[rows] = _nag_guidance(output[rows], output_neg, NAG)
         return output
 
-    def _window_softmax(self, qkv_handoff):
+    def _nag_window_softmax(self, query, key, value, NAG, force_attention, dense_rows, groups):
+        from shared.attention import pay_attention
+
+        query_neg, key_neg, value_neg = NAG.pop("qkv")
+        text_len, mask = NAG["text_len"], NAG["mask"]
+        shift = key_neg.shape[1] - text_len
+        key = torch.cat((key_neg, key[:, text_len:]), dim=1)
+        value = torch.cat((value_neg, value[:, text_len:]), dim=1)
+        del key_neg, value_neg
+        NAG["attention"] = pay_attention([query_neg, key, value], force_attention=force_attention, recycle_q=True)
+        del query_neg
+        if "window_plan" not in NAG:
+            # Window keys are absolute rows: a caption longer than the prompt moves every later key by the difference.
+            shifted = _window_plan(self.layout, self.video_start + shift, self.frames, self.tokens_per_frame, self.bounds, query.device)[1]
+            NAG["window_plan"] = (dense_rows[mask[dense_rows]],
+                                  [(rows[mask[rows]], indices) for (rows, _), (_, indices) in zip(groups, shifted)])
+        dense_rows, groups = NAG["window_plan"]
+        output = torch.empty_like(query)
+        output[:, dense_rows] = pay_attention([query[:, dense_rows], key, value], force_attention=force_attention, recycle_q=True)
+        for rows, indices in groups:
+            if rows.numel():
+                output[:, rows] = pay_attention([query[:, rows], key[:, indices], value[:, indices]], force_attention=force_attention, recycle_q=True)
+        return output[0, NAG["rows"]]
+
+    def _window_softmax(self, qkv_handoff, NAG=None):
         from shared.attention import pay_attention, sage2_supported
 
         query, key, value = qkv_handoff
@@ -366,6 +411,8 @@ class VDNHybridAttention(nn.Module):
         dense_rows, groups = _window_plan(self.layout, video_start, frames, per_frame, self.bounds, query.device)
         if force_attention == "sage2":
             _notify_sage()
+        if NAG is not None:
+            NAG["local"] = self._nag_window_softmax(query, key, value, NAG, force_attention, dense_rows, groups)
         output[:, dense_rows] = pay_attention([query[:, dense_rows], key, value], force_attention=force_attention, recycle_q=True)
         for rows, indices in groups:
             output[:, rows] = pay_attention([query[:, rows], key[:, indices], value[:, indices]], force_attention=force_attention, recycle_q=True)


### PR DESCRIPTION
MiniMax H3 is a distilled model without CFG, so it currently hides the negative prompt. This adds Normalized Attention Guidance to H3, the way Wan, Flux, Krea2, LTX-2 and Z-Image already offer it: the negative prompt box and the three NAG sliders appear, and nothing changes while NAG Scale is 1.

**Where it sits**

- `minimax_h3_handler.py` declares `NAG` and shows the negative prompt for the FL2VA / REF2VA models, with the usual `NAG_scale` / `NAG_tau` / `NAG_alpha` defaults. Viggle keeps it hidden (fixed prompt, no text encoder), and the audio-only models are unchanged.
- `wgp.py` is untouched: it already passes `n_prompt` and the NAG settings.
- `pipeline.py` encodes the negative prompt once per phase and hands `{"scale", "tau", "alpha", "context"}` to the transformer in the payload it already builds, as Z-Image and Flux pass their `NAG` dict. The negative caption is padded to the prompt's token count, so a short negative prompt does not guide by its length alone.
- `transformer.py` / `vdn_attention.py` consume it inside attention. H3 is single-stream, so the negative branch is built as Flux builds it: a second attention pass in which the negative caption's keys and values take the place of the prompt's, and the combine is the same in-place NAG arithmetic as `models/wan/modules/model.py`. The negative caption goes through every block with the text rows' own modulation, norms and MLP, rather than staying at its encoder output.

Guidance applies to every row after the caption, including rows that carry supplied input (a start image, keyframes, continuation latents, preserved mask areas), as Wan's and LTX-2's NAG guide every row. The caption rows themselves are not guided: the negative caption takes their place in the negative branch.

The combine runs in float32 and writes the result back in the model's dtype. With a negative identical to the positive, the extrapolation should return the positive exactly. At scale 11 the half-precision form of the same arithmetic misses by a mean 5.6e-03 against activations of mean magnitude 0.80 (a CPU probe on random activations), while float32 is exact.

On VDN checkpoints both halves of the hybrid attention run for the negative caption, with the linear half reading the negative caption's text state. Guidance then applies once, to the summed attention output, so the negative branch is the same computation as the positive one. In blind side-by-side text-to-video renders, guiding the softmax half alone, or each half separately, made no consistent visible difference.

**Cost**

For each block the negative branch is one more attention pass over the guided rows, against keys that span the whole sequence, which is the price Flux pays too. Sol Attention replaces that attention call, so combining it with NAG raises a clear error instead of silently doing nothing.

**Tested**

On MiniMax H3, with a VDN checkpoint (text-to-video and image-to-video) and the FL2VA Pruned checkpoint on SDPA (text-to-video):

- With NAG Scale at 1 the output is bit-identical to an unpatched checkout, video and audio, on both checkpoints.
- With a negative prompt and NAG Scale above 1, the output moves away from what the negative names. On the FL2VA Pruned checkpoint with the prompt "a car in nature", the negative "trees, green" makes the scene clearly less green, while "snow, night", which names nothing in it, leaves it about as green as without guidance.
- On the VDN checkpoint the guided text-to-video output is bit-identical, video and audio, to our earlier out-of-tree implementation of this guidance.
- Image-to-video on the VDN checkpoint at NAG Scale 4, same seed, with the start image's rows guided (this PR) and left unguided: the first frame matches the start image as closely either way (PSNR 36.57 against 36.54 dB), the step from the first frame into the motion is no harder, and side by side neither the video nor the audio is worse.
- On the SDPA path the negative caption's own rows are attended in the same call as the guided rows, the way `models/flux/math.py:30-50` takes `neg_out` from its single negative pass; the earlier implementation gave them a separate call. Under the flash kernel that call shape alone moves the caption rows' attention output by at most 2.4e-04 (0 under the efficient and cuDNN kernels). With the separate call put back, the output is bit-identical to the earlier implementation, so that call shape is the only difference between the two.

A negative caption identical to the prompt leaves the output unchanged, and turning NAG off restores the original output exactly. Both were checked on small real DiT and VDN block stacks, in addition to the renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
