### PR TITLE
Output filename: add Configuration > Outputs global default template and per-generation fallback chain

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -90,6 +90,20 @@ Let's generate a simple text-to-video:
 
 ## Basic Settings Explained
 
+### Output File Names
+
+Generated files are named automatically by default (timestamp, seed and a short version of the prompt). The name can be customized with a template in two places:
+
+- **Misc tab → Output Filename**: applies to one model and is saved in `settings/<model>_settings.json` (via *Set Settings as Default*)
+- **Configuration → Outputs → Default Output Filename (all models)**: a global default saved in `wgp_config.json`, used for every model that does not have its own value
+
+Resolution order per generation: the Misc box value (if not empty) → the model settings file value → the global default → the automatic naming. Both templates use the placeholders listed in the Misc tab hint.
+
+Notes:
+
+- No GUI restart is needed for filename changes: the model settings file is re-read on every generation and the global default is read from the current server configuration. The Misc box keeps the value it was initialized with until the form is rebuilt (model switch or restart).
+- A template in the model settings file or the global default that cannot be formatted (unknown placeholder, bad format spec) is skipped with a console warning and the automatic naming is used instead. A template typed directly in the Misc box fails the generation, so a typo is noticed.
+
 ### Generation Settings
 - **Frames**: Number of frames (more = longer video)
   - 25 frames ≈ 1 second

--- a/plugins/configuration/plugin.py
+++ b/plugins/configuration/plugin.py
@@ -608,6 +608,11 @@ class ConfigTabPlugin(WAN2GPPlugin):
                         label="Embed Source Images",
                         info="Saves i2v source images inside MP4/MOV/MKV files"
                     )
+                    self.output_filename_default_choice = gr.Textbox(
+                        value=self.server_config.get("output_filename_default", ""),
+                        label="Default Output Filename (all models)",
+                        info="Template used when a model has no Output Filename set in the Misc tab. Same placeholders as the Misc box (see docs/GETTING_STARTED.md)."
+                    )
                     self.video_save_path_choice = gr.Textbox(label="Video Output Folder (requires restart)", value=self.save_path)
                     self.image_save_path_choice = gr.Textbox(label="Image Output Folder (requires restart)", value=self.image_save_path)
                     self.audio_save_path_choice = gr.Textbox(label="Audio Output Folder (requires restart)", value=self.audio_save_path)
@@ -739,7 +744,7 @@ class ConfigTabPlugin(WAN2GPPlugin):
             self.deepy_type_choice, self.deepy_vram_mode_choice, self.deepy_allow_read_file_system_choice, self.deepy_file_system_paths_choice, self.deepy_read_everywhere_choice,
             self.deepy_context_tokens_choice, self.deepy_kv_cache_quantization_choice, self.deepy_compaction_type_choice, self.deepy_repetition_penalty_choice, self.deepy_zero_custom_system_prompt_choice, self.deepy_prime_custom_system_prompt_choice, self.deepy_prime_mcp_servers_choice, self.deepy_mcp_auto_discover_paths_choice,
             self.video_container_choice, self.video_output_codec_choice, self.hdr_video_crf_choice, self.image_output_codec_choice, self.audio_output_codec_choice, self.audio_stand_alone_output_codec_choice,
-            self.metadata_choice, self.embed_source_images_choice,
+            self.metadata_choice, self.embed_source_images_choice, self.output_filename_default_choice,
             self.video_save_path_choice, self.image_save_path_choice, self.audio_save_path_choice,
             self.notification_sound_enabled_choice, self.notification_sound_volume_choice, self.notification_apprise_urls_choice, self.notification_secure_storage_choice, self.notification_on_generation_choice, self.notification_on_queue_complete_choice, self.notification_on_queue_interrupted_choice,
             *self.audio_processor_config_components,
@@ -831,7 +836,7 @@ class ConfigTabPlugin(WAN2GPPlugin):
             deepy_type_choice, deepy_vram_mode_choice, deepy_allow_read_file_system_choice, deepy_file_system_paths_choice, deepy_read_everywhere_choice,
             deepy_context_tokens_choice, deepy_kv_cache_quantization_choice, deepy_compaction_type_choice, deepy_repetition_penalty_choice, deepy_zero_custom_system_prompt_choice, deepy_prime_custom_system_prompt_choice, deepy_prime_mcp_servers_choice, deepy_mcp_auto_discover_paths_choice,
             video_container_choice, video_output_codec_choice, hdr_video_crf_choice, image_output_codec_choice, audio_output_codec_choice, audio_stand_alone_output_codec_choice,
-            metadata_choice, embed_source_images_choice,
+            metadata_choice, embed_source_images_choice, output_filename_default_choice,
             save_path_choice, image_save_path_choice, audio_save_path_choice,
             notification_sound_enabled_choice, notification_sound_volume_choice, notification_apprise_urls_choice, notification_secure_storage_choice, notification_on_generation_choice, notification_on_queue_complete_choice, notification_on_queue_interrupted_choice,
             last_resolution_choice
@@ -978,6 +983,7 @@ class ConfigTabPlugin(WAN2GPPlugin):
             gradio_queue_focus_patch.FOCUS_QUEUE_SERVER_CONFIG_KEY: process_queues_when_browser_unfocused_choice,
             "embed_source_images": embed_source_images_choice,
             "video_container": video_container_choice,
+            "output_filename_default": output_filename_default_choice,
             "last_model_type": state["model_type"],
             "last_model_per_family": state["last_model_per_family"],
             "last_model_per_type": state["last_model_per_type"],
@@ -1011,7 +1017,7 @@ class ConfigTabPlugin(WAN2GPPlugin):
             "prompt_enhancer_temperature", "prompt_enhancer_top_p", "prompt_enhancer_randomize_seed", "prompt_enhancer_quantization", PROMPT_ENHANCER_SPECULATIVE_DECODING_KEY, "enhancer_mode",
             DEEPY_ENABLED_KEY, DEEPY_TYPE_KEY, DEEPY_VRAM_MODE_KEY, DEEPY_ALLOW_READ_FILE_SYSTEM_KEY, DEEPY_FILE_SYSTEM_PATHS_KEY, DEEPY_READ_EVERYWHERE_KEY, DEEPY_CONTEXT_TOKENS_KEY, DEEPY_KV_CACHE_QUANTIZATION_KEY, DEEPY_COMPACTION_TYPE_KEY, DEEPY_REPETITION_PENALTY_KEY, DEEPY_ZERO_CUSTOM_SYSTEM_PROMPT_KEY, DEEPY_PRIME_CUSTOM_SYSTEM_PROMPT_KEY, DEEPY_PRIME_MCP_SERVERS_KEY, DEEPY_MCP_AUTO_DISCOVER_PATHS_KEY,
             LLM_CONFIG_KEY,
-            "max_frames_multiplier", "display_stats", "keep_resolution_on_model_switch", "enable_4k_resolutions", "max_reserved_loras", "video_output_codec", "hdr_video_crf", "video_container",
+            "max_frames_multiplier", "display_stats", "keep_resolution_on_model_switch", "enable_4k_resolutions", "max_reserved_loras", "video_output_codec", "hdr_video_crf", "video_container", "output_filename_default",
             "embed_source_images", "image_output_codec", "audio_output_codec", "audio_stand_alone_output_codec", "checkpoints_paths", "loras_root", "save_queue_if_crash",
             "model_hierarchy_type", "UI_theme", "queue_color_scheme", gradio_queue_focus_patch.FOCUS_QUEUE_SERVER_CONFIG_KEY
         ]

--- a/wgp.py
+++ b/wgp.py
@@ -3056,6 +3056,38 @@ def get_transformer_dtype(model_type, transformer_dtype_policy):
 def get_settings_file_name(model_type):
     return  os.path.join(args.settings, model_type + "_settings.json")
 
+def get_saved_output_filename(model_type):
+    """Return the Output Filename template saved in the model settings file, or "" if absent."""
+    try:
+        with open(get_settings_file_name(model_type), "r", encoding="utf-8") as f:
+            return json.load(f).get("output_filename", "") or ""
+    except (OSError, json.JSONDecodeError):
+        return ""
+
+def resolve_stored_output_filename(model_type, settings):
+    """Fallback filename template for generations whose Misc Output Filename box is empty.
+
+    Resolution order: the model settings file value, then the global
+    Configuration > Outputs default. A stored template that cannot be formatted
+    is skipped with a console warning (and the next source tried) instead of
+    failing the generation, unlike a template typed in the Misc box.
+
+    Returns the formatted filename (without extension) or None, in which case
+    the caller falls back to the default auto naming.
+    """
+    from shared.utils.filename_formatter import FilenameFormatter
+    for label, template in (
+        ("model settings file", get_saved_output_filename(model_type)),
+        ("Configuration > Outputs default", server_config.get("output_filename_default", "")),
+    ):
+        if not len(template):
+            continue
+        try:
+            return FilenameFormatter.format_filename(template, settings)
+        except ValueError as exc:
+            print(f"[Wan2GP] Ignoring {label} output filename template {template!r}: {exc}; using default naming")
+    return None
+
 def fix_postprocess_audio_settings(ui_defaults, settings_version):
     return audio_processor_api.fix_settings(ui_defaults, settings_version, attachment_has_path_values=_attachment_has_path_values)
 
@@ -8293,7 +8325,14 @@ def generate_media(
                     file_name = f"{sanitize_file_name(truncate_for_filesystem(os.path.splitext(os.path.basename(file_name))[0])).strip()}.{extension}"
                     file_name = os.path.basename(get_available_filename(output_dir, file_name))
                 else:
-                    file_name = f"{time_flag}_seed{seed}_{sanitize_file_name(truncate_for_filesystem(save_prompt)).strip()}.{extension}"
+                    # No Misc box template: model settings file, then the global
+                    # Configuration > Outputs default, then the default auto naming
+                    file_name = resolve_stored_output_filename(model_type, inputs)
+                    if file_name is None:
+                        file_name = f"{time_flag}_seed{seed}_{sanitize_file_name(truncate_for_filesystem(save_prompt)).strip()}.{extension}"
+                    else:
+                        file_name = f"{sanitize_file_name(truncate_for_filesystem(os.path.splitext(os.path.basename(file_name))[0])).strip()}.{extension}"
+                        file_name = os.path.basename(get_available_filename(output_dir, file_name))
                 video_path = os.path.join(output_dir, file_name)
 
                 if BGRA_frames is not None:

--- a/wgp.py
+++ b/wgp.py
@@ -3064,6 +3064,46 @@ def get_saved_output_filename(model_type):
     except (OSError, json.JSONDecodeError):
         return ""
 
+def stored_output_filename_templates(model_type):
+    """(label, template) pairs of the stored Output Filename templates, in resolution order.
+
+    The model settings file value first, then the global Configuration >
+    Outputs default. They only apply when the Misc Output Filename box is
+    left empty.
+    """
+    return (
+        ("model settings file", get_saved_output_filename(model_type)),
+        ("Configuration > Outputs default", server_config.get("output_filename_default", "")),
+    )
+
+def precheck_output_filename(model_type, output_filename):
+    """Check output filename template compliance before a generation starts.
+
+    A template typed in the Misc Output Filename box must only use known
+    placeholders: if it is not compliant, fail now with a clear error instead
+    of only when the finished video is saved, where the failure would lose
+    the whole generation (which may have taken hours).
+
+    When the Misc box is empty, the stored templates cannot make a generation
+    fail: they are skipped with a console warning at save time (see
+    resolve_stored_output_filename). The same warning is printed here as well
+    so the user is informed before a long generation starts.
+    """
+    from shared.utils.filename_formatter import FilenameFormatter
+    if not len(output_filename or ""):
+        for label, template in stored_output_filename_templates(model_type):
+            if not len(template):
+                continue
+            try:
+                FilenameFormatter(template)
+            except ValueError as exc:
+                print(f"[Wan2GP] Ignoring {label} output filename template {template!r}: {exc}; using default naming")
+        return
+    try:
+        FilenameFormatter(output_filename)
+    except ValueError as exc:
+        raise ValueError(f"Invalid Output Filename template {output_filename!r}: {exc}. Fix the template or leave the box empty for auto naming, then start the generation again.")
+
 def resolve_stored_output_filename(model_type, settings):
     """Fallback filename template for generations whose Misc Output Filename box is empty.
 
@@ -3076,10 +3116,7 @@ def resolve_stored_output_filename(model_type, settings):
     the caller falls back to the default auto naming.
     """
     from shared.utils.filename_formatter import FilenameFormatter
-    for label, template in (
-        ("model settings file", get_saved_output_filename(model_type)),
-        ("Configuration > Outputs default", server_config.get("output_filename_default", "")),
-    ):
+    for label, template in stored_output_filename_templates(model_type):
         if not len(template):
             continue
         try:
@@ -3087,6 +3124,59 @@ def resolve_stored_output_filename(model_type, settings):
         except ValueError as exc:
             print(f"[Wan2GP] Ignoring {label} output filename template {template!r}: {exc}; using default naming")
     return None
+
+def validate_startup_output_filename():
+    """Report non-compliant stored output filename templates at server start.
+
+    The global default (Configuration > Outputs, "output_filename_default" in
+    wgp_config.json) is only loaded into the in-memory server config at
+    startup, and the per-model templates (settings/<model>_settings.json) are
+    only re-read when a generation for that model starts: this check is the
+    earliest moment a typo in them can be reported, before any video is
+    generated. It prints a console warning for each non-compliant template.
+    It never aborts the startup: per the stored-template policy, generations
+    still proceed with the next source in the chain (or automatic naming).
+    """
+    from shared.utils.filename_formatter import FilenameFormatter
+
+    def check(label, template, fallback_hint):
+        if not isinstance(template, str) or not len(template):
+            return
+        try:
+            FilenameFormatter(template)
+        except ValueError as exc:
+            print(f"[Wan2GP] WARNING: the {label} is not compliant and will be skipped at generation time:")
+            print(f"[Wan2GP]   template: {template!r}")
+            print(f"[Wan2GP]   {exc}")
+            print(f"[Wan2GP]   {fallback_hint}")
+
+    check(
+        "global default output filename template (Configuration > Outputs, \"output_filename_default\" in wgp_config.json)",
+        server_config.get("output_filename_default", ""),
+        "Generations with an empty Misc Output Filename box use the model settings file value or automatic naming. Fix the template in Configuration > Outputs or in wgp_config.json.",
+    )
+    settings_dir = args.settings
+    if os.path.isdir(settings_dir):
+        for file_name in sorted(os.listdir(settings_dir)):
+            if not file_name.endswith("_settings.json"):
+                continue
+            try:
+                with open(os.path.join(settings_dir, file_name), "r", encoding="utf-8") as f:
+                    stored = json.load(f)
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(stored, dict):
+                continue
+            check(
+                f"output filename template in the model settings file {file_name}",
+                stored.get("output_filename", ""),
+                f"Generations with an empty Misc Output Filename box use the Configuration > Outputs default or automatic naming. Fix {file_name} via the Misc tab (Set Settings as Default).",
+            )
+
+
+# Report invalid stored output filename templates at server start, before any
+# generation can be started with them.
+validate_startup_output_filename()
 
 def fix_postprocess_audio_settings(ui_defaults, settings_version):
     return audio_processor_api.fix_settings(ui_defaults, settings_version, attachment_has_path_values=_attachment_has_path_values)
@@ -6920,6 +7010,10 @@ def generate_media(
                 video_length = min_frames_if_references if "I" in video_prompt_type or "V" in video_prompt_type else 1 
     else:
         batch_size = 1
+    # Check the output filename template before doing any work: a template
+    # with unknown placeholders would otherwise only fail when the finished
+    # video is saved, losing the whole generation (which may take hours).
+    precheck_output_filename(model_type, output_filename)
     temp_filenames_list = []
 
     if image_guide is not None:


### PR DESCRIPTION
## What

Adds a global default output filename template and makes the per-model value take effect without a GUI restart. It also validates templates early, so a typo is caught before (or at the start of) a long generation instead of only after it.

New field: **Configuration → Outputs → Default Output Filename (all models)** (stored as `output_filename_default` in `wgp_config.json`, next to the other Outputs settings).

### Settings precedence (core of this PR)

The output filename is resolved from the **first non-empty source** in this order:

| # | Source | Stored in | In this PR |
|---|---|---|---|
| 1 | Misc tab → **Output Filename** box (value in the box at generation time) | `settings/<model>_settings.json` (via *Set Settings as Default*) | **unchanged, checked earlier** — a non-empty box always wins; a template that cannot be formatted **fails the generation** — now when the generation starts, before the model is loaded and inference runs — so a typo is noticed and no hours-long generation is lost |
| 2 | Per-model **Output Filename** value | `settings/<model>_settings.json` (key `output_filename`) | **changed** — the file is now **re-read on every generation** (previously only reachable through the box, which is initialized when the form is built); a value that cannot be formatted is skipped with a console warning (also reported at generation start and at server start) and level 3 is tried |
| 3 | **Default Output Filename (all models)** | `wgp_config.json` (key `output_filename_default`) | **new** — applies to every model that has no value of its own; a value that cannot be formatted is skipped with a console warning (also reported at server start) |
| 4 | Automatic naming (`timestamp_seed_prompt`) | — | **unchanged** — final fallback when 1–3 are all empty or invalid |

Notes on the chain:

- Levels 2–3 need **no restart**: the model file is re-read per generation and the global default is read from the live server config (registered in `no_reload_keys`, like the other Outputs-tab settings). This is what makes an externally edited `settings/<model>_settings.json` apply to the next generation immediately, instead of waiting for a model switch or a GUI restart. The Misc box (level 1) keeps the value it was initialized with until the form is rebuilt.
- Levels 1–3 share the same placeholder set (the Misc tab hint) and the same post-processing: filename sanitization, extension append, collision avoidance.
- The level-1 save-time code path is byte-for-byte unchanged; the new precheck runs earlier (see *Validation* below).

### Where it is documented

`docs/GETTING_STARTED.md` → **`## Basic Settings Explained` → `### Output File Names`** (lines 93–105 on this branch; the precedence rule is the sentence on line 100). The section states the two configuration locations, the resolution order, the no-restart behavior, and the invalid-template policy.

### Validation (new in this revision)

Two early checks, both built on the existing `FilenameFormatter` template validation (unknown-placeholder detection) — no new failure modes:

- **Before a generation starts** — `precheck_output_filename()`, called at the top of `generate_media()`, before model loading/inference, on both the Gradio queue and the CLI `--process` path: a non-compliant template typed in the Misc box **fails the generation immediately** with a clear error (previously it could only fail at save time, after a possibly hours-long generation); when the box is empty and a *stored* template (levels 2–3) is non-compliant, the existing warn-and-skip console warning is also printed up front, so the user knows before waiting.
- **At server start** — `validate_startup_output_filename()`, called at module level in `wgp.py`: non-compliant stored templates (the global default and each `settings/<model>_settings.json`) are reported on the console before the server URL is displayed, so a typo in a stored template is noticed before any generation runs. It never aborts startup: per the stored-template policy, generations still proceed with the next source in the chain.
- Known limitation (inherited from the formatter, all versions): only `{...}` tokens are placeholders, so a bracket typo like `[date}` or `{date]` is treated as **literal text**, passes every check, and lands in the filename as-is. Detecting that would require a dedicated heuristic and is out of scope here.

## Files

- `wgp.py`: new helpers `get_saved_output_filename()` (reads the model file without the `fix_settings` side effects), `stored_output_filename_templates()` (shared source of the stored chain), `resolve_stored_output_filename()` (the fallback chain), `precheck_output_filename()` (pre-generation compliance check, called at the top of `generate_media()`) and `validate_startup_output_filename()` (startup check, called at module level); the `else` branch of the filename site in `generate_media()` uses the chain
- `plugins/configuration/plugin.py`: new Textbox in the Outputs tab plus the usual save plumbing (`inputs`, unpack, `new_server_config`) and `no_reload_keys` entry
- `docs/GETTING_STARTED.md`: new "Output File Names" section under Basic Settings (resolution order, no-restart note, invalid-template policy)

## Related and prior work

- **[#752](https://github.com/deepbeepmeep/Wan2GP/pull/752) and [#1057](https://github.com/deepbeepmeep/Wan2GP/pull/1057) (chshkhr, closed, unmerged)** — the original community requests for *custom output filenames* (workflow automation via external queue generation). Both were superseded: the maintainer implemented the feature himself — the now-shipped Misc tab box + `FilenameFormatter`.
- **What this PR offers beyond that lineage:**
  - those PRs and the shipped feature only cover *one model at a time* (a single level: box or auto-naming). This PR adds a **global default** (Configuration → Outputs) that serves every model without its own value;
  - it defines and documents a **three-level + auto-naming precedence chain** (box → per-model file → global → auto), instead of a two-level if/else;
  - the per-model file is **re-read on every generation**, so a change (via *Set Settings as Default* or a direct JSON edit) applies to the next generation with **no restart**;
  - an **invalid stored template** (file or global) is skipped with a console warning and the chain continues, instead of breaking every generation — a value typed in the Misc box still fails loudly (now at generation start);
  - non-compliant stored templates are additionally reported **at server start**, before any generation is run.
- **[#2290](https://github.com/deepbeepmeep/Wan2GP/pull/2290) (abencq, open)** — complementary, not overlapping: extends the placeholder set (effective output values) and adds Python format-spec support. This PR works with the original placeholder set; if #2290 lands first, the doc section can cross-reference its placeholder table.
- #2290 and this PR touch `wgp.py` at the same filename site but in disjoint regions (#2290: the `if` branch + Misc hint; this PR: the `else` branch + module-level helpers), so they merge cleanly in either order.
